### PR TITLE
design: デザインシステムをライトモードに全面再設計

### DIFF
--- a/.antigravity/skills/design_system.md
+++ b/.antigravity/skills/design_system.md
@@ -1,11 +1,34 @@
 # Skill: Design System Integrity
 あなたは、一貫性のないスタイルを一切許さない、厳格なデザインシステムエンジニアです。
 
-- **Color Strategy**: 
-  - `text-gray-500` などの直接指定ではなく、`text-muted-foreground` などのセマンティックな命名を使用する。
-- **Spacing**:
-  - すべての余白は `4` の倍数（Tailwindの 1 unit = 0.25rem）で構成し、8, 16, 24, 32... のリズムを徹底する。
-- **Component Pattern**:
-  - `shadcn/ui` をベースにするが、独自の「Glassmorphism（背景ぼかし）」や「Neumorphism」のスパイスを Tailwind の `backdrop-blur` や `shadow` ユーティリティで加える。
-- **Dark Mode**:
-  - 単なる白黒反転ではなく、ダークモード時の彩度を調整し、目が疲れないコントラストを維持する。
+## ⚠️ 絶対に避けるべきパターン（AI感の源泉）
+- **漆黒背景 + 紫/インディゴ系アクセント** は禁止。`#050505`, `#818cf8`, `#6366f1` を新規に使わない。
+- `bg-black`, `bg-zinc-900`, `bg-gray-900` などの漆黒ベースも禁止。
+- 汎用的な「プレミアム感」演出（`from-purple`, `via-indigo`, `to-violet` グラデーション）は禁止。
+
+## カラートークン体系
+このプロダクトのテーマは **「脚本・人生のシナリオ」** — 紙、インク、活字、万年筆の質感。
+
+- **背景**: `#F5F0E8`（クリーム / 古い原稿用紙）
+- **前景**: `#2C2C28`（インクブラック / 純黒より柔らかい）
+- **ミュート**: `#6B5E4E`（古びたインクの薄さ / WCAG AA準拠）
+- **Engine Mode アクセント**: `--color-engine-accent` (`#2C2C28`) — 余計な色を置かない、白紙に黒インクの潔さ
+- **Compass Mode アクセント**: `--color-compass` (`#2D6A6A`) — 万年筆のDeep Teal、思索・内省の静けさ
+
+## Color Strategy
+- `text-gray-500` などの直接指定ではなく、`text-muted-foreground` などのセマンティックな命名を使用する。
+- Compass関連には必ず `text-compass`, `bg-compass-subtle`, `border-compass-border` のトークンを使う。
+- ハードコードの `white/5`, `white/10` などは `foreground/5`, `foreground/10` に置き換える。
+
+## Spacing
+- すべての余白は `4` の倍数（Tailwindの 1 unit = 0.25rem）で構成し、8, 16, 24, 32... のリズムを徹底する。
+
+## Typography
+- **本文・UI全体**: `Zen Kaku Gothic New`（ゴシック）。フォールバック: `Hiragino Kaku Gothic ProN`, sans-serif。
+- **ページタイトルのみ**: `Shippori Mincho`（活版印刷の質感）。`font-display` ユーティリティで適用。フォールバック: `Hiragino Mincho ProN`, serif。
+- **フォント切り替えは最小限に**: 「Follow the Script.」「Compass」「Roadmap」の3箇所のみ `font-display`。コンポーネント内の見出しには使わない。チャットUIなど読む・入力する場面はゴシック体を維持する。
+
+## Component Pattern
+- `shadcn/ui` をベースにするが、独自の「Glassmorphism（背景ぼかし）」のスパイスを Tailwind の `backdrop-blur` や `shadow` ユーティリティで加える。
+- ライトモードのグラスは `glass` / `glass-hover` ユーティリティを使う（白みがかった透過 + 柔らかい影）。
+- Compass専用は `glass-compass` / `glass-compass-hover` を使う（Tealがかった透過）。

--- a/src/app/compass/page.tsx
+++ b/src/app/compass/page.tsx
@@ -72,7 +72,7 @@ export default function CompassPage() {
         animate={{ opacity: 1, y: 0 }}
         transition={{ ...springTransition, delay: 0.05 }}
       >
-        <h1 className="text-xl sm:text-2xl font-bold tracking-tighter bg-clip-text text-transparent bg-gradient-to-br from-compass via-compass-muted to-compass/50">
+        <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tighter bg-clip-text text-transparent bg-gradient-to-br from-compass via-compass-muted to-compass/50">
           Compass
         </h1>
         <p className="text-xs sm:text-sm text-muted-foreground max-w-xl mx-auto">
@@ -109,7 +109,7 @@ export default function CompassPage() {
         transition={{ delay: 0.2 }}
       >
         <div className="text-center space-y-2">
-          <h2 className="text-xl sm:text-2xl font-bold tracking-tight">
+          <h2 className="font-display text-xl sm:text-2xl font-bold tracking-tight">
             Roadmap
           </h2>
           <p className="text-sm text-muted-foreground">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,92 +1,108 @@
+@import url('https://fonts.googleapis.com/css2?family=Shippori+Mincho:wght@400;500;600;700;800&family=Zen+Kaku+Gothic+New:wght@300;400;500;700;900&display=swap');
 @import "tailwindcss";
 
 @theme {
-  --color-background: #050505;
-  --color-foreground: #fafafa;
-  --color-card: rgba(255, 255, 255, 0.03);
-  --color-card-foreground: #fafafa;
-  --color-popover: #0a0a0a;
-  --color-popover-foreground: #fafafa;
-  --color-primary: #fafafa;
-  --color-primary-foreground: #171717;
-  --color-secondary: #262626;
-  --color-secondary-foreground: #fafafa;
-  --color-muted: #171717;
-  --color-muted-foreground: #a3a3a3;
-  --color-accent: #171717;
-  --color-accent-foreground: #fafafa;
-  --color-destructive: #7f1d1d;
-  --color-destructive-foreground: #fafafa;
-  --color-border: rgba(255, 255, 255, 0.1);
-  --color-input: rgba(255, 255, 255, 0.1);
-  --color-ring: #d4d4d8;
+  /* ベース: クリーム / 古い原稿用紙 */
+  --color-background: #F5F0E8;
+  --color-foreground: #2C2C28;
+  --color-card: rgba(26, 26, 24, 0.04);
+  --color-card-foreground: #1A1A18;
+  --color-popover: #EDE8DF;
+  --color-popover-foreground: #1A1A18;
+  --color-primary: #2C2C28;
+  --color-primary-foreground: #F5F0E8;
+  --color-secondary: rgba(26, 26, 24, 0.07);
+  --color-secondary-foreground: #1A1A18;
+  --color-muted: rgba(26, 26, 24, 0.06);
+  --color-muted-foreground: #6B5E4E;
+  --color-accent: rgba(26, 26, 24, 0.07);
+  --color-accent-foreground: #1A1A18;
+  --color-destructive: #9B2335;
+  --color-destructive-foreground: #F5F0E8;
+  --color-border: rgba(26, 26, 24, 0.1);
+  --color-input: rgba(26, 26, 24, 0.08);
+  --color-ring: #1A1A18;
   --radius-lg: 0.75rem;
   --radius-md: calc(0.75rem - 2px);
   --radius-sm: calc(0.75rem - 4px);
 
-  /* Compass Mode: 静寂・内省的なインディゴ/バイオレットのアクセント */
-  --color-compass: #818cf8;
-  --color-compass-foreground: #fafafa;
-  --color-compass-muted: #6366f1;
-  --color-compass-subtle: rgba(129, 140, 248, 0.1);
-  --color-compass-border: rgba(129, 140, 248, 0.2);
+  /* Engine Mode: インクブラック。装飾しない */
+  --color-engine-accent: #2C2C28;
+
+  /* Compass Mode: 万年筆のインク — Deep Teal。思索・内省の静けさ */
+  --color-compass: #2D6A6A;
+  --color-compass-foreground: #F5F0E8;
+  --color-compass-muted: #235454;
+  --color-compass-subtle: rgba(45, 106, 106, 0.08);
+  --color-compass-border: rgba(45, 106, 106, 0.18);
 }
 
-/* 
-  Skill: Design System Integrity (Dark Mode First)
-  プレミアムで洗練された「Engine Mode」の世界観に合わせるため、
-  深みのある漆黒と、僅かな透過を利用した上品なダークモードをベースとします。
+/*
+  Skill: Design System Integrity
+  「脚本・人生のシナリオ」の世界観に合わせた、
+  クリームベース × インクブラック × Deep Teal のライトモードシステム。
+  AI感のある漆黒 + 紫グラデーションから脱却し、
+  紙・活字・万年筆の質感を纏う。
 */
 
 :root {
   background-color: var(--color-background);
   color: var(--color-foreground);
-  color-scheme: dark;
+  color-scheme: light;
 }
 
-/* 
+/*
   Glassmorphism Utilities
-  独自の「Glassmorphism（背景ぼかし）」や「Neumorphism」のスパイス
+  ライトモード向け: 白みがかった透過 + 柔らかい影
 */
 @utility glass {
-  background-color: rgba(255, 255, 255, 0.03);
+  background-color: rgba(255, 255, 254, 0.6);
   backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(26, 26, 24, 0.08);
+  box-shadow: 0 1px 3px rgba(26, 26, 24, 0.06);
 }
 
 @utility glass-hover {
-  background-color: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 254, 0.8);
+  border-color: rgba(26, 26, 24, 0.14);
+  box-shadow: 0 2px 6px rgba(26, 26, 24, 0.08);
 }
 
-/* Compass Mode 専用グラスモーフィズム — 青み帯びた透過 */
+/* Compass Mode 専用グラスモーフィズム — Tealがかった透過 */
 @utility glass-compass {
-  background-color: rgba(99, 102, 241, 0.04);
+  background-color: rgba(45, 106, 106, 0.04);
   backdrop-filter: blur(16px);
-  border: 1px solid rgba(129, 140, 248, 0.1);
+  border: 1px solid rgba(45, 106, 106, 0.12);
+  box-shadow: 0 1px 3px rgba(45, 106, 106, 0.06);
 }
 
 @utility glass-compass-hover {
-  background-color: rgba(99, 102, 241, 0.08);
-  border-color: rgba(129, 140, 248, 0.2);
+  background-color: rgba(45, 106, 106, 0.08);
+  border-color: rgba(45, 106, 106, 0.2);
+  box-shadow: 0 2px 6px rgba(45, 106, 106, 0.1);
 }
 
 /* Chat bubble styles */
 @utility bubble-user {
-  background-color: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: rgba(26, 26, 24, 0.05);
+  border: 1px solid rgba(26, 26, 24, 0.08);
 }
 
 @utility bubble-assistant {
-  background-color: rgba(99, 102, 241, 0.06);
-  border: 1px solid rgba(129, 140, 248, 0.1);
+  background-color: rgba(45, 106, 106, 0.06);
+  border: 1px solid rgba(45, 106, 106, 0.12);
 }
 
 body {
-  font-family: 'Inter', Arial, Helvetica, sans-serif;
+  font-family: 'Zen Kaku Gothic New', 'Hiragino Kaku Gothic ProN', sans-serif;
   margin: 0;
   min-height: 100vh;
-  /* 宇宙空間や高級感を感じさせる繊細なグラデーション背景 */
-  background: radial-gradient(circle at 50% 0%, #1a1a1a 0%, #050505 50%, #000000 100%);
+  /* 古い原稿用紙のような、中央からわずかに明るいクリームグラデーション */
+  background: radial-gradient(ellipse at 50% 0%, #FAF6EE 0%, #F5F0E8 50%, #EDE8DF 100%);
   background-attachment: fixed;
+}
+
+/* 見出し: 活版印刷の質感を纏う Shippori Mincho */
+@utility font-display {
+  font-family: 'Shippori Mincho', 'Hiragino Mincho ProN', serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,6 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 import { HeaderNav } from "@/components/ui/HeaderNav";
-
-const inter = Inter({
-  subsets: ["latin"],
-  variable: "--font-inter",
-});
 
 export const metadata: Metadata = {
   title: "Script",
@@ -32,10 +26,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ja" className={`dark ${inter.variable}`}>
-      <body className="antialiased text-foreground min-h-screen font-[family-name:var(--font-inter)]">
-        {/* Subtle top glow line for premium feel */}
-        <div className="fixed top-0 inset-x-0 h-[1px] bg-gradient-to-r from-transparent via-white/20 to-transparent z-50 pointer-events-none" />
+    <html lang="ja">
+      <body className="antialiased text-foreground min-h-screen">
+        {/* Subtle top line for premium feel */}
+        <div className="fixed top-0 inset-x-0 h-[1px] bg-gradient-to-r from-transparent via-foreground/10 to-transparent z-50 pointer-events-none" />
 
         <HeaderNav />
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,7 +26,7 @@ export default function Home() {
   return (
     <div className="flex flex-col items-center w-full max-w-3xl mx-auto space-y-4 pt-2 sm:pt-4">
       <div className="text-center space-y-1">
-        <h1 className="text-xl sm:text-2xl font-bold tracking-tighter bg-clip-text text-transparent bg-gradient-to-br from-white to-white/50">
+        <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tighter bg-clip-text text-transparent bg-gradient-to-br from-foreground to-foreground/50">
           Follow the Script.
         </h1>
         <p className="text-xs sm:text-sm text-muted-foreground max-w-xl mx-auto">

--- a/src/components/features/compass/GoalInput.tsx
+++ b/src/components/features/compass/GoalInput.tsx
@@ -96,7 +96,7 @@ export function GoalInput({ onSubmit, isLoading }: GoalInputProps) {
           className={cn(
             "p-3 rounded-xl flex items-center justify-center transition-colors",
             goal.trim() && !isLoading
-              ? "bg-compass text-white hover:bg-compass-muted"
+              ? "bg-compass text-compass-foreground hover:bg-compass-muted"
               : "bg-secondary text-muted-foreground cursor-not-allowed"
           )}
         >

--- a/src/components/features/compass/PhilosophyChat.tsx
+++ b/src/components/features/compass/PhilosophyChat.tsx
@@ -177,7 +177,7 @@ export function PhilosophyChat({
           className={cn(
             "p-3 rounded-xl flex items-center justify-center transition-colors",
             input.trim() && !isChatLoading
-              ? "bg-compass text-white hover:bg-compass-muted"
+              ? "bg-compass text-compass-foreground hover:bg-compass-muted"
               : "bg-secondary text-muted-foreground cursor-not-allowed"
           )}
         >

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -167,7 +167,7 @@ function AddMilestoneForm({ onAdd, onCancel }: AddMilestoneFormProps) {
         <button
           type="submit"
           disabled={!period.trim() || !title.trim()}
-          className="px-3 py-1.5 rounded-lg text-xs font-medium bg-compass text-white disabled:opacity-40 disabled:cursor-not-allowed"
+          className="px-3 py-1.5 rounded-lg text-xs font-medium bg-compass text-compass-foreground disabled:opacity-40 disabled:cursor-not-allowed"
         >
           追加
         </button>

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -379,7 +379,7 @@ export function TaskItem({
             initial={{ opacity: 0, height: 0, marginTop: 0 }}
             animate={{ opacity: 1, height: "auto", marginTop: 8 }}
             exit={{ opacity: 0, height: 0, marginTop: 0 }}
-            className="overflow-hidden pl-4 pr-0 border-l-2 border-white/5 ml-2"
+            className="overflow-hidden pl-4 pr-0 border-l-2 border-foreground/8 ml-2"
           >
             <div className="flex flex-col gap-1.5">
               {subTasks.map((subTask) => (
@@ -392,7 +392,7 @@ export function TaskItem({
                     onEdit={onEdit}
                     isSubTask
                   />
-                  <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-white/10" />
+                  <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />
                 </div>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- AIっぽい「漆黒 + 紫グラデ」から脱却し、「脚本・人生のシナリオ」の世界観に合わせたライトモードに全面再設計
- カラー・フォント・Glassmorphismを一新し、`design_system.md` に禁止パターンと方針を明文化

## Changes

### カラー
- 背景: 漆黒 `#050505` → クリーム `#F5F0E8`（古い原稿用紙）
- 前景: `#fafafa` → インクブラック `#2C2C28`
- ミュート: `#a3a3a3` → `#6B5E4E`（WCAG AA準拠）
- Compassアクセント: インディゴ `#818cf8` → Deep Teal `#2D6A6A`（万年筆のインク）

### フォント
- 本文: `Inter` → `Zen Kaku Gothic New`
- ページタイトルのみ: `Shippori Mincho`（活版印刷の質感）
- 切り替えは「Follow the Script.」「Compass」「Roadmap」の3箇所に限定

### その他
- Glassmorphismをライトモード向けに再設計（白みがかった透過 + 柔らかい影）
- `text-white` 等のハードコードを `text-compass-foreground` 等のセマンティックトークンに統一
- `design_system.md` にカラー/タイポグラフィ方針と禁止パターン（AI感の源泉）を追記

## Test plan
- [ ] Engine Mode: クリーム背景・インクブラックのテキスト・Glassmorphismカードの表示確認
- [ ] Compass Mode: Deep Tealアクセント・チャット・ロードマップの表示確認
- [ ] ページタイトルに Shippori Mincho、本文に Zen Kaku Gothic New が適用されていること
- [ ] モバイルでのレイアウト崩れがないこと

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)