### PR TITLE
feat: Phase 3 — Scheduling & Smart Nudge

### DIFF
--- a/src/app/api/breakdown/route.ts
+++ b/src/app/api/breakdown/route.ts
@@ -25,13 +25,19 @@ Respond STRICTLY with a JSON object matching this schema, without markdown forma
       "estimatedTime": "15分",
       "actionLink": "https://example.com/useful-link"
     }
-  ]
+  ],
+  "firstStep": "今すぐできる最小の着手行動（1文で、動詞で始める）"
 }
 
 Instructions for actionLink:
 - If a task involves buying something, provide an Amazon or specific store search link.
 - If it involves research, provide a Google specific search link or Wikipedia.
 - ONLY provide an actionLink if it's genuinely useful for immediate execution. Otherwise, optionally omit it.
+
+Instructions for firstStep:
+- Identify the single smallest action that would get the user started right now.
+- It should take less than 5 minutes and create momentum.
+- Write it as a concrete verb phrase in Japanese (e.g. "レシピ動画を1本だけ開いて見てみる").
 `;
 
 export async function POST(req: Request) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { TaskInput } from "@/components/features/task/TaskInput";
 import { TaskList } from "@/components/features/task/TaskList";
 import { useTasks } from "@/hooks/useTasks";
@@ -9,6 +10,8 @@ import { Trash2, Sparkles } from "lucide-react";
 const springTransition = { type: "spring" as const, stiffness: 260, damping: 20 };
 
 export default function Home() {
+  const [lastBreakdownTaskId, setLastBreakdownTaskId] = useState<string | null>(null);
+
   const {
     tasks,
     breakdownTask,
@@ -22,7 +25,16 @@ export default function Home() {
     isLoading,
     isBreakingDown,
     completedCount,
+    scheduleTask,
+    unscheduleTask,
   } = useTasks();
+
+  const handleBreakdown = async (prompt: string) => {
+    const newParentId = await breakdownTask(prompt);
+    if (newParentId) {
+      setLastBreakdownTaskId(newParentId);
+    }
+  };
 
   return (
     <div className="flex flex-col items-center w-full max-w-3xl mx-auto space-y-4 pt-2 sm:pt-4">
@@ -36,7 +48,7 @@ export default function Home() {
       </div>
 
       <div className="w-full relative z-10">
-        <TaskInput onSubmit={breakdownTask} isLoading={isLoading} />
+        <TaskInput onSubmit={handleBreakdown} isLoading={isLoading} />
 
         {isLoading && (
           <motion.div
@@ -70,6 +82,10 @@ export default function Home() {
               onEditTask={editTask}
               onReorderTasks={reorderTasks}
               onEditBreakdown={editBreakdown}
+              onScheduleTask={scheduleTask}
+              onUnscheduleTask={unscheduleTask}
+              newlyBreakdownTaskId={lastBreakdownTaskId}
+              onDismissSchedulingPrompt={() => setLastBreakdownTaskId(null)}
             />
 
             {/* Bulk action bar */}

--- a/src/components/features/task/SchedulingPicker.tsx
+++ b/src/components/features/task/SchedulingPicker.tsx
@@ -5,6 +5,7 @@ import { motion, AnimatePresence } from "framer-motion";
 import { Calendar, Clock, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
+import { getTodayStr, getTomorrowStr, getWeekendStr, formatDateLabel } from "@/lib/date";
 
 interface SchedulingPickerProps {
   onSchedule: (date: string, time?: string) => void;
@@ -21,35 +22,6 @@ const TIME_SLOT_VALUES: Record<Exclude<TimeSlot, "指定">, string> = {
   昼: "12:00",
   夜: "20:00",
 };
-
-function getTodayStr(): string {
-  const d = new Date();
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
-
-function getTomorrowStr(): string {
-  const d = new Date();
-  d.setDate(d.getDate() + 1);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
-
-function getWeekendStr(): string {
-  const d = new Date();
-  const day = d.getDay();
-  // 次の土曜日
-  const daysUntilSat = day === 6 ? 7 : (6 - day);
-  d.setDate(d.getDate() + daysUntilSat);
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-}
-
-function formatDateLabel(dateStr: string): string {
-  const today = getTodayStr();
-  const tomorrow = getTomorrowStr();
-  if (dateStr === today) return "今日";
-  if (dateStr === tomorrow) return "明日";
-  const d = new Date(dateStr);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
-}
 
 export function SchedulingPicker({
   onSchedule,

--- a/src/components/features/task/SchedulingPicker.tsx
+++ b/src/components/features/task/SchedulingPicker.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Calendar, Clock, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { springTransition } from "@/lib/motion";
+
+interface SchedulingPickerProps {
+  onSchedule: (date: string, time?: string) => void;
+  onSkip: () => void;
+  defaultDate?: string;
+  defaultTime?: string;
+  compact?: boolean;
+}
+
+type TimeSlot = "朝" | "昼" | "夜" | "指定";
+
+const TIME_SLOT_VALUES: Record<Exclude<TimeSlot, "指定">, string> = {
+  朝: "08:00",
+  昼: "12:00",
+  夜: "20:00",
+};
+
+function getTodayStr(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function getTomorrowStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function getWeekendStr(): string {
+  const d = new Date();
+  const day = d.getDay();
+  // 次の土曜日
+  const daysUntilSat = day === 6 ? 7 : (6 - day);
+  d.setDate(d.getDate() + daysUntilSat);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function formatDateLabel(dateStr: string): string {
+  const today = getTodayStr();
+  const tomorrow = getTomorrowStr();
+  if (dateStr === today) return "今日";
+  if (dateStr === tomorrow) return "明日";
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+export function SchedulingPicker({
+  onSchedule,
+  onSkip,
+  defaultDate,
+  defaultTime,
+  compact = false,
+}: SchedulingPickerProps) {
+  const [selectedDate, setSelectedDate] = useState<string>(defaultDate ?? "");
+  const [showTimePicker, setShowTimePicker] = useState(!!defaultTime);
+  const [selectedTimeSlot, setSelectedTimeSlot] = useState<TimeSlot | null>(null);
+  const [customTime, setCustomTime] = useState(defaultTime ?? "");
+  const [showCalendar, setShowCalendar] = useState(false);
+
+  const quickDates = [
+    { label: "今日", value: getTodayStr() },
+    { label: "明日", value: getTomorrowStr() },
+    { label: "今週末", value: getWeekendStr() },
+  ];
+
+  const handleDateSelect = (date: string) => {
+    setSelectedDate(date);
+    setShowTimePicker(true);
+    setShowCalendar(false);
+  };
+
+  const handleTimeSlotSelect = (slot: TimeSlot) => {
+    setSelectedTimeSlot(slot);
+    if (slot !== "指定") {
+      setCustomTime(TIME_SLOT_VALUES[slot]);
+    }
+  };
+
+  const handleConfirm = () => {
+    if (!selectedDate) return;
+    let time: string | undefined;
+    if (showTimePicker && selectedTimeSlot) {
+      if (selectedTimeSlot === "指定") {
+        time = customTime || undefined;
+      } else {
+        time = TIME_SLOT_VALUES[selectedTimeSlot];
+      }
+    }
+    onSchedule(selectedDate, time);
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -8, scale: 0.98 }}
+      animate={{ opacity: 1, y: 0, scale: 1 }}
+      exit={{ opacity: 0, y: -8, scale: 0.98 }}
+      transition={springTransition}
+      className={cn(
+        "glass rounded-2xl border border-foreground/10 overflow-hidden",
+        compact ? "p-3" : "p-4"
+      )}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <p className="text-sm font-medium text-foreground/80 flex items-center gap-1.5">
+          <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
+          いつやりますか？
+        </p>
+        <motion.button
+          onClick={onSkip}
+          className="p-1 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"
+          whileTap={{ scale: 0.9 }}
+          transition={springTransition}
+          aria-label="スキップ"
+        >
+          <X className="w-3.5 h-3.5" />
+        </motion.button>
+      </div>
+
+      {/* Quick date buttons */}
+      <div className="flex gap-2 mb-2">
+        {quickDates.map((qd) => (
+          <motion.button
+            key={qd.value}
+            onClick={() => handleDateSelect(qd.value)}
+            className={cn(
+              "flex-1 py-1.5 rounded-xl text-xs font-medium transition-all border",
+              selectedDate === qd.value
+                ? "bg-foreground text-background border-foreground"
+                : "bg-secondary/30 border-foreground/10 text-foreground/70 hover:bg-secondary/50 hover:text-foreground"
+            )}
+            whileTap={{ scale: 0.95 }}
+            transition={springTransition}
+          >
+            {qd.label}
+          </motion.button>
+        ))}
+      </div>
+
+      {/* Calendar toggle */}
+      <motion.button
+        onClick={() => setShowCalendar((prev) => !prev)}
+        className="w-full flex items-center gap-2 py-1.5 px-3 rounded-xl text-xs text-muted-foreground hover:text-foreground hover:bg-secondary/30 transition-colors mb-2"
+        whileTap={{ scale: 0.98 }}
+        transition={springTransition}
+      >
+        <Calendar className="w-3.5 h-3.5" />
+        {selectedDate && !quickDates.find((qd) => qd.value === selectedDate)
+          ? `📅 ${formatDateLabel(selectedDate)}`
+          : "📅 カレンダーから選ぶ"}
+      </motion.button>
+
+      <AnimatePresence>
+        {showCalendar && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={springTransition}
+            className="overflow-hidden mb-2"
+          >
+            <input
+              type="date"
+              value={selectedDate}
+              min={getTodayStr()}
+              onChange={(e) => handleDateSelect(e.target.value)}
+              className="w-full bg-secondary/20 border border-foreground/10 rounded-xl px-3 py-1.5 text-sm text-foreground outline-none focus:border-foreground/30 transition-colors"
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Time picker — only shown after a date is selected */}
+      <AnimatePresence>
+        {showTimePicker && selectedDate && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={springTransition}
+            className="overflow-hidden"
+          >
+            <div className="border-t border-foreground/10 pt-2 mt-1">
+              <p className="text-xs text-muted-foreground flex items-center gap-1 mb-2">
+                <Clock className="w-3 h-3" />
+                時間も決める（任意）
+              </p>
+              <div className="flex gap-1.5 flex-wrap">
+                {(["朝", "昼", "夜", "指定"] as TimeSlot[]).map((slot) => (
+                  <motion.button
+                    key={slot}
+                    onClick={() => handleTimeSlotSelect(slot)}
+                    className={cn(
+                      "px-3 py-1 rounded-lg text-xs font-medium transition-all border",
+                      selectedTimeSlot === slot
+                        ? "bg-foreground text-background border-foreground"
+                        : "bg-secondary/30 border-foreground/10 text-foreground/70 hover:bg-secondary/50 hover:text-foreground"
+                    )}
+                    whileTap={{ scale: 0.95 }}
+                    transition={springTransition}
+                  >
+                    {slot}
+                  </motion.button>
+                ))}
+              </div>
+
+              <AnimatePresence>
+                {selectedTimeSlot === "指定" && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={springTransition}
+                    className="overflow-hidden mt-2"
+                  >
+                    <input
+                      type="time"
+                      value={customTime}
+                      onChange={(e) => setCustomTime(e.target.value)}
+                      className="bg-secondary/20 border border-foreground/10 rounded-xl px-3 py-1.5 text-sm text-foreground outline-none focus:border-foreground/30 transition-colors"
+                    />
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Footer actions */}
+      <div className="flex items-center justify-between mt-3 pt-2 border-t border-foreground/10">
+        <motion.button
+          onClick={onSkip}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors py-1 px-2 rounded-lg hover:bg-secondary/30"
+          whileTap={{ scale: 0.95 }}
+          transition={springTransition}
+        >
+          後で決める
+        </motion.button>
+        <motion.button
+          onClick={handleConfirm}
+          disabled={!selectedDate}
+          className={cn(
+            "text-xs font-medium px-4 py-1.5 rounded-xl transition-all",
+            selectedDate
+              ? "bg-foreground text-background hover:bg-foreground/90"
+              : "bg-secondary/30 text-muted-foreground cursor-not-allowed"
+          )}
+          whileTap={selectedDate ? { scale: 0.95 } : {}}
+          transition={springTransition}
+        >
+          決定
+        </motion.button>
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/features/task/SchedulingPicker.tsx
+++ b/src/components/features/task/SchedulingPicker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Calendar, Clock, X } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -13,6 +13,7 @@ interface SchedulingPickerProps {
   defaultDate?: string;
   defaultTime?: string;
   compact?: boolean;
+  taskTitle?: string;
 }
 
 type TimeSlot = "朝" | "昼" | "夜" | "指定";
@@ -29,6 +30,7 @@ export function SchedulingPicker({
   defaultDate,
   defaultTime,
   compact = false,
+  taskTitle,
 }: SchedulingPickerProps) {
   const [selectedDate, setSelectedDate] = useState<string>(defaultDate ?? "");
   const [showTimePicker, setShowTimePicker] = useState(!!defaultTime);
@@ -36,11 +38,11 @@ export function SchedulingPicker({
   const [customTime, setCustomTime] = useState(defaultTime ?? "");
   const [showCalendar, setShowCalendar] = useState(false);
 
-  const quickDates = [
+  const quickDates = useMemo(() => [
     { label: "今日", value: getTodayStr() },
     { label: "明日", value: getTomorrowStr() },
     { label: "今週末", value: getWeekendStr() },
-  ];
+  ], []);
 
   const handleDateSelect = (date: string) => {
     setSelectedDate(date);
@@ -81,10 +83,17 @@ export function SchedulingPicker({
     >
       {/* Header */}
       <div className="flex items-center justify-between mb-3">
-        <p className="text-sm font-medium text-foreground/80 flex items-center gap-1.5">
-          <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
-          いつやりますか？
-        </p>
+        <div className="flex flex-col gap-0.5">
+          <p className="text-sm font-medium text-foreground/80 flex items-center gap-1.5">
+            <Calendar className="w-3.5 h-3.5 text-muted-foreground" />
+            いつやりますか？
+          </p>
+          {taskTitle && (
+            <p className="text-xs text-muted-foreground pl-5 truncate max-w-[220px]">
+              {taskTitle}
+            </p>
+          )}
+        </div>
         <motion.button
           onClick={onSkip}
           className="p-1 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/50 transition-colors"

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { CheckCircle2, Circle, Compass, X, GripVertical, Pencil, Play, Undo2, Wand2, Send, Loader2 } from "lucide-react";
+import { CheckCircle2, Circle, Compass, X, GripVertical, Pencil, Play, Undo2, Wand2, Send, Loader2, CalendarDays } from "lucide-react";
+import { SchedulingPicker } from "./SchedulingPicker";
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
 import { toast } from "sonner";
@@ -21,6 +22,9 @@ export interface Task {
   linkedRoadmapId?: string;
   linkedMilestoneId?: string;
   parentId?: string;
+  scheduledDate?: string;
+  scheduledTime?: string;
+  firstStep?: string;
 }
 
 interface TaskItemProps {
@@ -30,11 +34,39 @@ interface TaskItemProps {
   onDelete: (id: string) => void;
   onEdit: (id: string, newTitle: string) => void;
   onEditBreakdown?: (taskId: string, instruction: string) => Promise<void>;
+  onScheduleTask?: (id: string, date: string, time?: string) => void;
+  onUnscheduleTask?: (id: string) => void;
   index?: number;
   onDragStart?: (index: number) => void;
   onDragOver?: (index: number) => void;
   onDragEnd?: () => void;
   isSubTask?: boolean;
+}
+
+function formatScheduleBadge(date: string, time?: string): string {
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
+
+  let dateLabel: string;
+  if (date === todayStr) dateLabel = "今日";
+  else if (date === tomorrowStr) dateLabel = "明日";
+  else {
+    const d = new Date(date);
+    dateLabel = `${d.getMonth() + 1}/${d.getDate()}`;
+  }
+
+  if (!time) return dateLabel;
+
+  const [h] = time.split(":").map(Number);
+  let timeLabel: string;
+  if (h !== undefined && h < 10) timeLabel = "朝";
+  else if (h !== undefined && h < 15) timeLabel = "昼";
+  else timeLabel = "夜";
+
+  return `${dateLabel} ${timeLabel}`;
 }
 
 const itemVariants = {
@@ -50,6 +82,8 @@ export function TaskItem({
   onDelete,
   onEdit,
   onEditBreakdown,
+  onScheduleTask,
+  onUnscheduleTask,
   index = 0,
   onDragStart,
   onDragOver,
@@ -63,6 +97,7 @@ export function TaskItem({
   const [aiInstruction, setAiInstruction] = useState("");
   const [isAIEditing, setIsAIEditing] = useState(false);
   const [aiError, setAiError] = useState<string | null>(null);
+  const [isSchedulePickerOpen, setIsSchedulePickerOpen] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const aiInputRef = useRef<HTMLTextAreaElement>(null);
 
@@ -320,6 +355,18 @@ export function TaskItem({
                       <span className="opacity-70">↗</span> Link
                     </a>
                   )}
+                  {task.scheduledDate && !isSubTask && (
+                    <motion.button
+                      onClick={() => onUnscheduleTask?.(task.id)}
+                      className="flex items-center gap-1 bg-secondary/50 px-2 py-0.5 rounded-md text-xs text-muted-foreground hover:bg-destructive/20 hover:text-destructive-foreground transition-colors"
+                      whileTap={{ scale: 0.95 }}
+                      transition={springTransition}
+                      title="スケジュールを解除"
+                    >
+                      <CalendarDays className="w-3 h-3 opacity-70" />
+                      {formatScheduleBadge(task.scheduledDate, task.scheduledTime)}
+                    </motion.button>
+                  )}
 
                   {hasSubtasks && (
                     <button
@@ -413,6 +460,24 @@ export function TaskItem({
                       <Wand2 className="w-3.5 h-3.5" />
                     </motion.button>
                   )}
+                  {!isSubTask && task.status !== "done" && onScheduleTask && (
+                    <motion.button
+                      onClick={() => setIsSchedulePickerOpen((prev) => !prev)}
+                      className={cn(
+                        "p-1.5 rounded-lg transition-colors opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100",
+                        isSchedulePickerOpen
+                          ? "text-foreground bg-secondary/50"
+                          : "text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+                      )}
+                      whileTap={{ scale: 0.9 }}
+                      transition={springTransition}
+                      title="スケジュール"
+                      aria-label="スケジュールを設定"
+                      aria-pressed={isSchedulePickerOpen}
+                    >
+                      <CalendarDays className="w-3.5 h-3.5" />
+                    </motion.button>
+                  )}
                   <motion.button
                     onClick={() => onDelete(task.id)}
                     className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive-foreground hover:bg-destructive/20 transition-colors opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100"
@@ -476,6 +541,50 @@ export function TaskItem({
         )}
       </AnimatePresence>
 
+      {/* Scheduling Picker Panel */}
+      <AnimatePresence>
+        {isSchedulePickerOpen && (
+          <motion.div
+            initial={{ opacity: 0, height: 0, marginTop: 0 }}
+            animate={{ opacity: 1, height: "auto", marginTop: 8 }}
+            exit={{ opacity: 0, height: 0, marginTop: 0 }}
+            transition={springTransition}
+            className="overflow-hidden"
+          >
+            <SchedulingPicker
+              defaultDate={task.scheduledDate}
+              defaultTime={task.scheduledTime}
+              onSchedule={(date, time) => {
+                onScheduleTask?.(task.id, date, time);
+                setIsSchedulePickerOpen(false);
+              }}
+              onSkip={() => setIsSchedulePickerOpen(false)}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* First Step hint */}
+      <AnimatePresence>
+        {task.firstStep && task.status !== "done" && task.status !== "canceled" && !isSubTask && (
+          <motion.div
+            initial={{ opacity: 0, height: 0, marginTop: 0 }}
+            animate={{ opacity: 1, height: "auto", marginTop: 6 }}
+            exit={{ opacity: 0, height: 0, marginTop: 0 }}
+            transition={springTransition}
+            className="overflow-hidden"
+          >
+            <div className="flex items-start gap-2 px-2 py-1.5 rounded-xl bg-secondary/30 border border-foreground/5">
+              <span className="text-xs text-muted-foreground mt-0.5 flex-shrink-0">⚡</span>
+              <p className="text-xs text-muted-foreground">
+                <span className="font-medium text-foreground/70">まず: </span>
+                {task.firstStep}
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+
       {/* Subtasks Accordion */}
       <AnimatePresence>
         {isExpanded && hasSubtasks && (
@@ -495,6 +604,8 @@ export function TaskItem({
                     onDelete={onDelete}
                     onEdit={onEdit}
                     onEditBreakdown={onEditBreakdown}
+                    onScheduleTask={onScheduleTask}
+                    onUnscheduleTask={onUnscheduleTask}
                     isSubTask
                   />
                   <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -6,6 +6,7 @@ import { CheckCircle2, Circle, Compass, X, GripVertical, Pencil, Play, Undo2, Wa
 import { SchedulingPicker } from "./SchedulingPicker";
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
+import { formatScheduleBadge } from "@/lib/date";
 import { toast } from "sonner";
 
 export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'canceled';
@@ -43,31 +44,6 @@ interface TaskItemProps {
   isSubTask?: boolean;
 }
 
-function formatScheduleBadge(date: string, time?: string): string {
-  const today = new Date();
-  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
-  const tomorrow = new Date(today);
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  const tomorrowStr = `${tomorrow.getFullYear()}-${String(tomorrow.getMonth() + 1).padStart(2, "0")}-${String(tomorrow.getDate()).padStart(2, "0")}`;
-
-  let dateLabel: string;
-  if (date === todayStr) dateLabel = "今日";
-  else if (date === tomorrowStr) dateLabel = "明日";
-  else {
-    const d = new Date(date);
-    dateLabel = `${d.getMonth() + 1}/${d.getDate()}`;
-  }
-
-  if (!time) return dateLabel;
-
-  const [h] = time.split(":").map(Number);
-  let timeLabel: string;
-  if (h !== undefined && h < 10) timeLabel = "朝";
-  else if (h !== undefined && h < 15) timeLabel = "昼";
-  else timeLabel = "夜";
-
-  return `${dateLabel} ${timeLabel}`;
-}
 
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
@@ -604,8 +580,6 @@ export function TaskItem({
                     onDelete={onDelete}
                     onEdit={onEdit}
                     onEditBreakdown={onEditBreakdown}
-                    onScheduleTask={onScheduleTask}
-                    onUnscheduleTask={onUnscheduleTask}
                     isSubTask
                   />
                   <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -71,7 +71,6 @@ export function TaskItem({
   const [isAIEditOpen, setIsAIEditOpen] = useState(false);
   const [aiInstruction, setAiInstruction] = useState("");
   const [isAIEditing, setIsAIEditing] = useState(false);
-  const [aiError, setAiError] = useState<string | null>(null);
   const [isSchedulePickerOpen, setIsSchedulePickerOpen] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const aiInputRef = useRef<HTMLTextAreaElement>(null);

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -44,7 +44,6 @@ interface TaskItemProps {
   isSubTask?: boolean;
 }
 
-
 const itemVariants = {
   hidden: { opacity: 0, y: 20 },
   show: { opacity: 1, y: 0, transition: springTransition },
@@ -331,7 +330,7 @@ export function TaskItem({
                       <span className="opacity-70">↗</span> Link
                     </a>
                   )}
-                  {task.scheduledDate && !isSubTask && (
+                  {task.scheduledDate && (
                     <motion.button
                       onClick={() => onUnscheduleTask?.(task.id)}
                       className="flex items-center gap-1 bg-secondary/50 px-2 py-0.5 rounded-md text-xs text-muted-foreground hover:bg-destructive/20 hover:text-destructive-foreground transition-colors"
@@ -436,7 +435,7 @@ export function TaskItem({
                       <Wand2 className="w-3.5 h-3.5" />
                     </motion.button>
                   )}
-                  {!isSubTask && task.status !== "done" && onScheduleTask && (
+                  {task.status !== "done" && onScheduleTask && (
                     <motion.button
                       onClick={() => setIsSchedulePickerOpen((prev) => !prev)}
                       className={cn(
@@ -580,6 +579,8 @@ export function TaskItem({
                     onDelete={onDelete}
                     onEdit={onEdit}
                     onEditBreakdown={onEditBreakdown}
+                    onScheduleTask={onScheduleTask}
+                    onUnscheduleTask={onUnscheduleTask}
                     isSubTask
                   />
                   <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -6,6 +6,7 @@ import { Task, TaskItem, TaskStatus } from "./TaskItem";
 import { SchedulingPicker } from "./SchedulingPicker";
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
+import { getTodayStr } from "@/lib/date";
 
 interface TaskListProps {
   tasks: Task[];
@@ -74,10 +75,7 @@ export function TaskList({
     [tasks]
   );
 
-  const todayStr = useMemo(() => {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-  }, []);
+  const todayStr = useMemo(() => getTodayStr(), []);
 
   const processedTasks: TaskWithIndex[] = useMemo(() => {
     if (viewMode === "project") {
@@ -215,7 +213,7 @@ export function TaskList({
             Projects
           </button>
           <button
-            onClick={() => setViewMode("today")}
+            onClick={() => { setViewMode("today"); onDismissSchedulingPrompt?.(); }}
             aria-pressed={viewMode === "today"}
             className={cn(
               "px-4 sm:px-6 py-1.5 sm:py-2 rounded-xl text-xs sm:text-sm font-medium transition-all duration-300",
@@ -245,6 +243,7 @@ export function TaskList({
                 onDismissSchedulingPrompt?.();
               }}
               onSkip={() => onDismissSchedulingPrompt?.()}
+              taskTitle={tasks.find((t) => t.id === newlyBreakdownTaskId)?.title}
             />
           </motion.div>
         )}

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -3,7 +3,9 @@
 import { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Task, TaskItem, TaskStatus } from "./TaskItem";
+import { SchedulingPicker } from "./SchedulingPicker";
 import { cn } from "@/lib/utils";
+import { springTransition } from "@/lib/motion";
 
 interface TaskListProps {
   tasks: Task[];
@@ -13,6 +15,11 @@ interface TaskListProps {
   onEditTask: (id: string, newTitle: string) => void;
   onReorderTasks: (fromIndex: number, toIndex: number) => void;
   onEditBreakdown?: (taskId: string, instruction: string) => Promise<void>;
+  onScheduleTask?: (id: string, date: string, time?: string) => void;
+  onUnscheduleTask?: (id: string) => void;
+  /** ID of the task that just had Breakdown run — shows inline SchedulingPicker */
+  newlyBreakdownTaskId?: string | null;
+  onDismissSchedulingPrompt?: () => void;
 }
 
 interface TaskWithIndex extends Task {
@@ -37,6 +44,10 @@ export function TaskList({
   onEditTask,
   onReorderTasks,
   onEditBreakdown,
+  onScheduleTask,
+  onUnscheduleTask,
+  newlyBreakdownTaskId,
+  onDismissSchedulingPrompt,
 }: TaskListProps) {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
@@ -63,6 +74,11 @@ export function TaskList({
     [tasks]
   );
 
+  const todayStr = useMemo(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  }, []);
+
   const processedTasks: TaskWithIndex[] = useMemo(() => {
     if (viewMode === "project") {
       return tasksWithIndex
@@ -72,6 +88,7 @@ export function TaskList({
           subTasks: tasksWithIndex.filter((st) => st.parentId === t.id),
         }));
     }
+    // Today mode: flat list of leaf tasks (no parents)
     return tasksWithIndex
       .filter((t) => {
         const isParent = tasksWithIndex.some((st) => st.parentId === t.id);
@@ -86,6 +103,7 @@ export function TaskList({
       });
   }, [tasksWithIndex, viewMode]);
 
+  // Project mode groups
   const inProgressTasks = useMemo(
     () => processedTasks.filter((t) => t.status === "in_progress"),
     [processedTasks]
@@ -99,13 +117,32 @@ export function TaskList({
     [processedTasks]
   );
 
+  // Today mode: 3-bucket split
+  const todayBucketTasks = useMemo(
+    () => processedTasks.filter((t) => t.scheduledDate === todayStr && t.status !== "done" && t.status !== "canceled"),
+    [processedTasks, todayStr]
+  );
+  const scheduledBucketTasks = useMemo(
+    () => processedTasks.filter((t) => t.scheduledDate && t.scheduledDate > todayStr && t.status !== "done" && t.status !== "canceled"),
+    [processedTasks, todayStr]
+  );
+  const somedayBucketTasks = useMemo(
+    () => processedTasks.filter((t) => !t.scheduledDate && t.status !== "done" && t.status !== "canceled"),
+    [processedTasks]
+  );
+  const doneBucketTasks = useMemo(
+    () => processedTasks.filter((t) => t.status === "done" || t.status === "canceled"),
+    [processedTasks]
+  );
+
   if (tasks.length === 0) return null;
 
   const renderGroup = (
     groupTasks: TaskWithIndex[],
     title: string,
     showEmptyIfZero = false,
-    compact = false
+    compact = false,
+    emptyMessage = "タスクはありません"
   ) => {
     if (groupTasks.length === 0 && !showEmptyIfZero) return null;
 
@@ -131,6 +168,8 @@ export function TaskList({
               onDelete={onDeleteTask}
               onEdit={onEditTask}
               onEditBreakdown={onEditBreakdown}
+              onScheduleTask={onScheduleTask}
+              onUnscheduleTask={onUnscheduleTask}
               onDragStart={handleDragStart}
               onDragOver={handleDragOver}
               onDragEnd={handleDragEnd}
@@ -145,7 +184,7 @@ export function TaskList({
               exit={{ opacity: 0 }}
               className="px-4 py-8 rounded-2xl border border-dashed border-border/40 text-center text-sm text-muted-foreground"
             >
-              実行中のタスクはありません
+              {emptyMessage}
             </motion.div>
           )}
         </AnimatePresence>
@@ -190,9 +229,41 @@ export function TaskList({
         </div>
       </div>
 
-      {renderGroup(inProgressTasks, "In Progress", false, viewMode === "today")}
-      {renderGroup(todoTasks, "Todo", false, viewMode === "today")}
-      {renderGroup(doneTasks, "Done", false, viewMode === "today")}
+      {/* Breakdown直後のインラインスケジューリングプロンプト */}
+      <AnimatePresence>
+        {newlyBreakdownTaskId && viewMode === "project" && onScheduleTask && (
+          <motion.div
+            initial={{ opacity: 0, y: -8, scale: 0.98 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: -8, scale: 0.98 }}
+            transition={springTransition}
+            className="mb-3"
+          >
+            <SchedulingPicker
+              onSchedule={(date, time) => {
+                onScheduleTask(newlyBreakdownTaskId, date, time);
+                onDismissSchedulingPrompt?.();
+              }}
+              onSkip={() => onDismissSchedulingPrompt?.()}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {viewMode === "project" ? (
+        <>
+          {renderGroup(inProgressTasks, "In Progress")}
+          {renderGroup(todoTasks, "Todo")}
+          {renderGroup(doneTasks, "Done")}
+        </>
+      ) : (
+        <>
+          {renderGroup(todayBucketTasks, "Today", true, true, "今日の予定はありません")}
+          {renderGroup(scheduledBucketTasks, "Scheduled", false, true)}
+          {renderGroup(somedayBucketTasks, "Someday", true, true, "いつかやるタスクはありません")}
+          {renderGroup(doneBucketTasks, "Done", false, true)}
+        </>
+      )}
     </motion.div>
   );
 }

--- a/src/components/ui/UserMenu.tsx
+++ b/src/components/ui/UserMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { User, LogOut, Loader2, Pencil, Check, X } from "lucide-react";
@@ -18,8 +18,14 @@ export function UserMenu() {
   const router = useRouter();
   const menuRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const supabase = useRef(createClient()).current;
+  const supabase = useMemo(() => createClient(), []);
   const { displayName, updateDisplayName } = useDisplayName();
+
+  const cancelEdit = () => {
+    setIsEditing(false);
+    setSaveError(null);
+    setEditValue("");
+  };
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) => {
@@ -60,12 +66,6 @@ export function UserMenu() {
     setEditValue(displayName);
     setSaveError(null);
     setIsEditing(true);
-  };
-
-  const cancelEdit = () => {
-    setIsEditing(false);
-    setSaveError(null);
-    setEditValue("");
   };
 
   const commitEdit = async () => {

--- a/src/hooks/useDisplayName.ts
+++ b/src/hooks/useDisplayName.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { createClient } from "@/lib/supabase/client";
 import { DisplayNameSchema } from "@/lib/schemas";
 
@@ -17,7 +17,7 @@ interface UseDisplayNameResult {
 export function useDisplayName(): UseDisplayNameResult {
   const [displayName, setDisplayName] = useState("");
   const [isFetching, setIsFetching] = useState(true);
-  const supabase = useRef(createClient()).current;
+  const supabase = useMemo(() => createClient(), []);
 
   useEffect(() => {
     let cancelled = false;

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
+import { getTodayStr } from "@/lib/date";
 import { z } from "zod";
 
 const SingleEditResponseSchema = z.object({ task: BreakdownTaskSchema });
@@ -155,36 +156,98 @@ export function useTasks() {
 
   const scheduleTask = useCallback(
     async (id: string, date: string, time?: string) => {
+      const target = tasks.find((t) => t.id === id);
+      if (!target) return;
+
+      const isParent = !target.parentId;
+
+      // 親タスクの場合: 未上書きのサブタスク（親と同じ日付 or 未設定）も一括更新
+      const inheritingSubTasks = isParent
+        ? tasks.filter(
+            (t) => t.parentId === id && (t.scheduledDate === target.scheduledDate)
+          )
+        : [];
+
+      const prevSnapshots = [target, ...inheritingSubTasks].map((t) => ({
+        id: t.id,
+        scheduledDate: t.scheduledDate,
+        scheduledTime: t.scheduledTime,
+      }));
+
+      // 楽観的更新
       setTasks((prev) =>
-        prev.map((t) =>
-          t.id === id
-            ? { ...t, scheduledDate: date, scheduledTime: time ?? undefined }
-            : t
-        )
+        prev.map((t) => {
+          if (t.id === id) return { ...t, scheduledDate: date, scheduledTime: time ?? undefined };
+          if (inheritingSubTasks.some((s) => s.id === t.id)) return { ...t, scheduledDate: date, scheduledTime: time ?? undefined };
+          return t;
+        })
       );
-      await supabase
+
+      const idsToUpdate = [id, ...inheritingSubTasks.map((t) => t.id)];
+      const { error } = await supabase
         .from("tasks")
         .update({ scheduled_date: date, scheduled_time: time ?? null })
-        .eq("id", id);
+        .in("id", idsToUpdate);
+
+      if (error) {
+        // ロールバック
+        setTasks((prev) =>
+          prev.map((t) => {
+            const snap = prevSnapshots.find((s) => s.id === t.id);
+            return snap ? { ...t, scheduledDate: snap.scheduledDate, scheduledTime: snap.scheduledTime } : t;
+          })
+        );
+      }
     },
-    [supabase]
+    [tasks, supabase]
   );
 
   const unscheduleTask = useCallback(
     async (id: string) => {
+      const target = tasks.find((t) => t.id === id);
+      if (!target) return;
+
+      const isParent = !target.parentId;
+
+      // 親タスクの場合: 未上書きのサブタスク（親と同じ日付）も一括解除
+      const inheritingSubTasks = isParent
+        ? tasks.filter(
+            (t) => t.parentId === id && t.scheduledDate === target.scheduledDate
+          )
+        : [];
+
+      const prevSnapshots = [target, ...inheritingSubTasks].map((t) => ({
+        id: t.id,
+        scheduledDate: t.scheduledDate,
+        scheduledTime: t.scheduledTime,
+      }));
+
+      // 楽観的更新
       setTasks((prev) =>
-        prev.map((t) =>
-          t.id === id
-            ? { ...t, scheduledDate: undefined, scheduledTime: undefined }
-            : t
-        )
+        prev.map((t) => {
+          if (t.id === id) return { ...t, scheduledDate: undefined, scheduledTime: undefined };
+          if (inheritingSubTasks.some((s) => s.id === t.id)) return { ...t, scheduledDate: undefined, scheduledTime: undefined };
+          return t;
+        })
       );
-      await supabase
+
+      const idsToUpdate = [id, ...inheritingSubTasks.map((t) => t.id)];
+      const { error } = await supabase
         .from("tasks")
         .update({ scheduled_date: null, scheduled_time: null })
-        .eq("id", id);
+        .in("id", idsToUpdate);
+
+      if (error) {
+        // ロールバック
+        setTasks((prev) =>
+          prev.map((t) => {
+            const snap = prevSnapshots.find((s) => s.id === t.id);
+            return snap ? { ...t, scheduledDate: snap.scheduledDate, scheduledTime: snap.scheduledTime } : t;
+          })
+        );
+      }
     },
-    [supabase]
+    [tasks, supabase]
   );
 
   // ─── Magic Breakdown ────────────────────────────────────────────────────────
@@ -446,10 +509,7 @@ export function useTasks() {
     [tasks]
   );
 
-  const todayStr = useMemo(() => {
-    const d = new Date();
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-  }, []);
+  const todayStr = useMemo(() => getTodayStr(), []);
 
   const todayTasks = useMemo(
     () => tasks.filter((t) => t.scheduledDate === todayStr),

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -205,14 +205,14 @@ export function useTasks() {
         }
 
         const parsed = BreakdownResponseSchema.safeParse(await response.json());
-        if (!parsed.success) return;
+        if (!parsed.success) return null;
 
         const {
           data: { user },
         } = await supabase.auth.getUser();
         if (!user) {
           console.warn("breakdownTask: user not authenticated");
-          return;
+          return null;
         }
 
         const parentId = uuidv4();

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -29,6 +29,9 @@ export function useTasks() {
       linked_goal: string | null;
       linked_roadmap_id: string | null;
       linked_milestone_id: string | null;
+      scheduled_date: string | null;
+      scheduled_time: string | null;
+      first_step: string | null;
       position: number;
     }): Task => ({
       id: row.id,
@@ -40,6 +43,9 @@ export function useTasks() {
       linkedGoal: row.linked_goal ?? undefined,
       linkedRoadmapId: row.linked_roadmap_id ?? undefined,
       linkedMilestoneId: row.linked_milestone_id ?? undefined,
+      scheduledDate: row.scheduled_date ?? undefined,
+      scheduledTime: row.scheduled_time ?? undefined,
+      firstStep: row.first_step ?? undefined,
     }),
     []
   );
@@ -145,10 +151,46 @@ export function useTasks() {
     await supabase.from("tasks").delete().in("id", ids);
   }, [tasks, supabase]);
 
+  // ─── Scheduling ────────────────────────────────────────────────────────────
+
+  const scheduleTask = useCallback(
+    async (id: string, date: string, time?: string) => {
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === id
+            ? { ...t, scheduledDate: date, scheduledTime: time ?? undefined }
+            : t
+        )
+      );
+      await supabase
+        .from("tasks")
+        .update({ scheduled_date: date, scheduled_time: time ?? null })
+        .eq("id", id);
+    },
+    [supabase]
+  );
+
+  const unscheduleTask = useCallback(
+    async (id: string) => {
+      setTasks((prev) =>
+        prev.map((t) =>
+          t.id === id
+            ? { ...t, scheduledDate: undefined, scheduledTime: undefined }
+            : t
+        )
+      );
+      await supabase
+        .from("tasks")
+        .update({ scheduled_date: null, scheduled_time: null })
+        .eq("id", id);
+    },
+    [supabase]
+  );
+
   // ─── Magic Breakdown ────────────────────────────────────────────────────────
 
   const breakdownTask = useCallback(
-    async (prompt: string) => {
+    async (prompt: string): Promise<string | null> => {
       setIsLoading(true);
 
       try {
@@ -174,6 +216,7 @@ export function useTasks() {
         }
 
         const parentId = uuidv4();
+        const firstStep = parsed.data.firstStep;
 
         // 親タスクを挿入
         await supabase.from("tasks").insert({
@@ -182,6 +225,7 @@ export function useTasks() {
           title: prompt,
           status: "todo",
           position: 0,
+          first_step: firstStep ?? null,
         });
 
         // 既存タスクの position をずらす
@@ -206,6 +250,7 @@ export function useTasks() {
           id: parentId,
           title: prompt,
           status: "todo",
+          firstStep,
         };
         const newTasks: Task[] = subTasks.map((t) => ({
           id: t.id,
@@ -217,8 +262,10 @@ export function useTasks() {
         }));
 
         setTasks((prev) => [parentTask, ...newTasks, ...prev]);
+        return parentId;
       } catch (error) {
         console.error("Failed to breakdown task:", error);
+        return null;
       } finally {
         setIsLoading(false);
       }
@@ -399,11 +446,34 @@ export function useTasks() {
     [tasks]
   );
 
+  const todayStr = useMemo(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  }, []);
+
+  const todayTasks = useMemo(
+    () => tasks.filter((t) => t.scheduledDate === todayStr),
+    [tasks, todayStr]
+  );
+
+  const scheduledTasks = useMemo(
+    () => tasks.filter((t) => t.scheduledDate && t.scheduledDate > todayStr),
+    [tasks, todayStr]
+  );
+
+  const somedayTasks = useMemo(
+    () => tasks.filter((t) => !t.scheduledDate && !t.parentId),
+    [tasks]
+  );
+
   return {
     tasks,
     isLoading: isLoading || isFetching,
     isBreakingDown: isLoading,
     completedCount,
+    todayTasks,
+    scheduledTasks,
+    somedayTasks,
     breakdownTask,
     editBreakdown,
     toggleTask,
@@ -413,5 +483,7 @@ export function useTasks() {
     reorderTasks,
     clearCompleted,
     importFromRoadmap,
+    scheduleTask,
+    unscheduleTask,
   };
 }

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,21 +1,21 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
 import { getTodayStr } from "@/lib/date";
+import { createClient } from "@/lib/supabase/client";
 import { z } from "zod";
 
 const SingleEditResponseSchema = z.object({ task: BreakdownTaskSchema });
-import { createClient } from "@/lib/supabase/client";
 
 export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(true);
 
-  const supabase = useRef(createClient()).current;
+  const supabase = useMemo(() => createClient(), []);
 
   // ─── DB rows → Task ────────────────────────────────────────────────────────
 
@@ -458,7 +458,6 @@ export function useTasks() {
         return result;
       });
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [tasks, supabase]
   );
 

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -26,18 +26,20 @@ export function formatDateLabel(dateStr: string): string {
   const tomorrow = getTomorrowStr();
   if (dateStr === today) return "今日";
   if (dateStr === tomorrow) return "明日";
-  const d = new Date(dateStr);
-  return `${d.getMonth() + 1}/${d.getDate()}`;
+  // "YYYY-MM-DD" を直接パース（new Date("YYYY-MM-DD") はUTC解釈でJSTで日付がずれる）
+  const [, m, dd] = dateStr.split("-").map(Number);
+  return `${m}/${dd}`;
 }
 
 export function formatScheduleBadge(date: string, time?: string): string {
   const dateLabel = formatDateLabel(date);
   if (!time) return dateLabel;
 
+  // TIME_SLOT_VALUES と対応させた逆引き
   const [h] = time.split(":").map(Number);
   let timeLabel: string;
-  if (h !== undefined && h < 10) timeLabel = "朝";
-  else if (h !== undefined && h < 15) timeLabel = "昼";
+  if (h >= 5 && h < 11) timeLabel = "朝";
+  else if (h >= 11 && h < 17) timeLabel = "昼";
   else timeLabel = "夜";
 
   return `${dateLabel} ${timeLabel}`;

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,44 @@
+export function toDateStr(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+export function getTodayStr(): string {
+  return toDateStr(new Date());
+}
+
+export function getTomorrowStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return toDateStr(d);
+}
+
+export function getWeekendStr(): string {
+  const d = new Date();
+  const day = d.getDay();
+  // 次の土曜日
+  const daysUntilSat = day === 6 ? 7 : 6 - day;
+  d.setDate(d.getDate() + daysUntilSat);
+  return toDateStr(d);
+}
+
+export function formatDateLabel(dateStr: string): string {
+  const today = getTodayStr();
+  const tomorrow = getTomorrowStr();
+  if (dateStr === today) return "今日";
+  if (dateStr === tomorrow) return "明日";
+  const d = new Date(dateStr);
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+export function formatScheduleBadge(date: string, time?: string): string {
+  const dateLabel = formatDateLabel(date);
+  if (!time) return dateLabel;
+
+  const [h] = time.split(":").map(Number);
+  let timeLabel: string;
+  if (h !== undefined && h < 10) timeLabel = "朝";
+  else if (h !== undefined && h < 15) timeLabel = "昼";
+  else timeLabel = "夜";
+
+  return `${dateLabel} ${timeLabel}`;
+}

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -15,6 +15,9 @@ export const RawTaskSchema = z.object({
   linkedGoal: z.string().optional(),
   linkedRoadmapId: z.string().optional(),
   linkedMilestoneId: z.string().optional(),
+  scheduledDate: z.string().optional(),
+  scheduledTime: z.string().optional(),
+  firstStep: z.string().optional(),
   // [The Thread - Phase 3設計メモ]
   // タスクとCompassの哲学・価値観を紐付けるフィールド。
   // Philosophy.values[n].name をIDとして使うか、別途 philosophyValueId を持つかは要検討。
@@ -33,6 +36,7 @@ export const BreakdownTaskSchema = z.object({
 
 export const BreakdownResponseSchema = z.object({
   tasks: z.array(BreakdownTaskSchema),
+  firstStep: z.string().optional(),
 });
 
 // ─── Compass: Chat ────────────────────────────────────────────────────────────

--- a/supabase/migrations/002_add_scheduled.sql
+++ b/supabase/migrations/002_add_scheduled.sql
@@ -1,0 +1,15 @@
+-- ============================================================
+-- 002_add_scheduled.sql
+-- Script — Phase 3: Scheduling & Smart Nudge
+-- ============================================================
+-- Adds scheduling columns to the tasks table so that tasks
+-- can be assigned a specific date/time (Implementation Intention).
+-- first_step stores the AI-generated "minimum first action" hint.
+-- ============================================================
+
+alter table tasks
+  add column scheduled_date date,
+  add column scheduled_time time,
+  add column first_step text;
+
+create index idx_tasks_scheduled_date on tasks(scheduled_date);


### PR DESCRIPTION
## 概要

Phase 3のコア機能「スケジューリング & Smart Nudge」を実装。タスクに日付・時間を紐付けることでImplementation Intentionを実現し、「いつかやる」を「約束」に変える。

## 実装内容

### DBマイグレーション
- `supabase/migrations/002_add_scheduled.sql`: `tasks`テーブルに`scheduled_date` / `scheduled_time` / `first_step`カラム追加

### スキーマ・型
- `src/lib/schemas.ts`: `RawTaskSchema`と`BreakdownResponseSchema`に新フィールド追加
- `src/components/features/task/TaskItem.tsx`: `Task`インターフェースに`scheduledDate` / `scheduledTime` / `firstStep`追加

### `useTasks.ts`拡張
- `scheduleTask(id, date, time?)` / `unscheduleTask(id)` メソッド追加（楽観的更新 + Supabase同期）
- `breakdownTask`が新親タスクのIDを返すよう変更
- `todayTasks` / `scheduledTasks` / `somedayTasks` 派生ステート追加

### `SchedulingPicker.tsx`（新規）
- クイック選択ボタン（今日・明日・今週末）
- インラインカレンダー（`<input type="date">`）
- 時間帯選択（朝/昼/夜/指定）
- 「後で決める」スキップ
- Framer Motionスプリングアニメーション

### `TaskItem.tsx`更新
- スケジュールバッジ（`📅 今日 朝`）の表示
- カレンダーボタンからインラインで`SchedulingPicker`を展開
- First Step hint（`⚡ まず: ...`）をBreakdown直後に表示

### `TaskList.tsx`更新（Todayビュー改修）
- Todayビューを3バケツ（Today / Scheduled / Someday）に分割
- Breakdown直後にインラインでスケジューリングプロンプトを表示

### Breakdown API拡張
- システムプロンプトに`firstStep`フィールドの指示を追加
- `BreakdownResponseSchema`に`firstStep: string?`を追加

## 関連

Closes #11
実装計画: #14

🤖 Generated with Claude Code Scheduled Task