### PR TITLE
AIによるサブタスク分割の精度をあげる

### DIFF
--- a/src/app/api/breakdown/edit/route.ts
+++ b/src/app/api/breakdown/edit/route.ts
@@ -14,17 +14,23 @@ const systemPrompt = `
 You are an expert AI task breakdown engine ("Magic Breakdown").
 The user has an existing task breakdown and wants to modify it based on their instruction.
 You will receive the original goal, the current subtasks, and an edit instruction.
-Apply the edit instruction to produce an updated list of 3 to 7 highly actionable, specific sub-tasks.
+Apply the edit instruction to produce an updated list of ALL steps needed to fully complete the task — from start to finish.
+The number of sub-tasks should match the complexity of the task (typically 3–10). You decide.
 Keep tasks not affected by the instruction as they are.
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).
 The task titles and any generated text must be in natural Japanese.
 
+TITLE RULES:
+- Each task title MUST be 20 characters or fewer.
+- Write as a short, punchy verb phrase (e.g. "材料をAmazonで注文する", "レシピ動画を3本見る").
+- No explanations, no parenthetical notes — just the action.
+
 Respond STRICTLY with a JSON object matching this schema, without markdown formatting:
 {
   "tasks": [
     {
-      "title": "動詞で始まる具体的で行動可能なステップ（日本語）",
+      "title": "動詞で始まる20文字以内の行動（日本語）",
       "estimatedTime": "15分",
       "actionLink": "https://example.com/useful-link"
     }

--- a/src/app/api/breakdown/edit/route.ts
+++ b/src/app/api/breakdown/edit/route.ts
@@ -15,7 +15,7 @@ You are an expert AI task breakdown engine ("Magic Breakdown").
 The user has an existing task breakdown and wants to modify it based on their instruction.
 You will receive the original goal, the current subtasks, and an edit instruction.
 Apply the edit instruction to produce an updated list of ALL steps needed to fully complete the task — from start to finish.
-The number of sub-tasks should match the complexity of the task (typically 3–10). You decide.
+The number of sub-tasks should match the complexity of the task: simple tasks may need 3 steps, complex projects may need 10 or more. You decide based on what is truly needed.
 Keep tasks not affected by the instruction as they are.
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).

--- a/src/app/api/breakdown/edit/single/route.ts
+++ b/src/app/api/breakdown/edit/single/route.ts
@@ -30,10 +30,15 @@ Take into account the other sub-tasks so the revised task does not duplicate or 
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).
 
+TITLE RULES:
+- The task title MUST be 20 characters or fewer.
+- Write as a short, punchy verb phrase (e.g. "材料をAmazonで注文する", "レシピ動画を3本見る").
+- No explanations, no parenthetical notes — just the action.
+
 Respond STRICTLY with a JSON object, without markdown formatting:
 {
   "task": {
-    "title": "動詞で始まる具体的で行動可能なステップ（日本語）",
+    "title": "動詞で始まる20文字以内の行動（日本語）",
     "estimatedTime": "15分",
     "actionLink": "https://example.com/useful-link"
   }

--- a/src/app/api/breakdown/route.ts
+++ b/src/app/api/breakdown/route.ts
@@ -11,17 +11,23 @@ const BreakdownRequestSchema = z.object({
 const systemPrompt = `
 You are an expert AI task breakdown engine ("Magic Breakdown").
 The user will give you a vague task, goal, or idea.
-Your job is to break it down into 3 to 5 highly actionable, specific, and friction-less sub-tasks.
+Your job is to break it down into ALL the steps needed to fully complete the task — from start to finish.
+The number of sub-tasks should match the complexity of the task: simple tasks may need 3 steps, complex projects may need 10 or more. You decide based on what is truly needed.
 Think about reducing the barrier to execution.
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).
 The task titles and any generated text must be in natural Japanese.
 
+TITLE RULES:
+- Each task title MUST be 20 characters or fewer.
+- Write as a short, punchy verb phrase that tells the user exactly what to do (e.g. "材料をAmazonで注文する", "レシピ動画を3本見る").
+- No explanations, no parenthetical notes — just the action.
+
 Respond STRICTLY with a JSON object matching this schema, without markdown formatting if possible, just the raw JSON:
 {
   "tasks": [
     {
-      "title": "動詞で始まる具体的で行動可能なステップ（日本語）",
+      "title": "動詞で始まる20文字以内の行動（日本語）",
       "estimatedTime": "15分",
       "actionLink": "https://example.com/useful-link"
     }

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -586,24 +586,14 @@ export function TaskItem({
                   <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />
                 </div>
               ))}
-              {subTasks.length >= 7 && !showAllSubtasks && (
+              {subTasks.length >= 7 && (
                 <motion.button
-                  onClick={() => setShowAllSubtasks(true)}
+                  onClick={() => setShowAllSubtasks((prev) => !prev)}
                   className="text-xs text-muted-foreground hover:text-foreground transition-colors py-1 px-2 rounded-lg hover:bg-secondary/50 text-left"
                   whileTap={{ scale: 0.97 }}
                   transition={springTransition}
                 >
-                  残り{subTasks.length - 6}個を表示
-                </motion.button>
-              )}
-              {subTasks.length >= 7 && showAllSubtasks && (
-                <motion.button
-                  onClick={() => setShowAllSubtasks(false)}
-                  className="text-xs text-muted-foreground hover:text-foreground transition-colors py-1 px-2 rounded-lg hover:bg-secondary/50 text-left"
-                  whileTap={{ scale: 0.97 }}
-                  transition={springTransition}
-                >
-                  折りたたむ
+                  {showAllSubtasks ? "折りたたむ" : `残り${subTasks.length - 6}個を表示`}
                 </motion.button>
               )}
             </div>

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -68,6 +68,7 @@ export function TaskItem({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(task.title);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showAllSubtasks, setShowAllSubtasks] = useState(false);
   const [isAIEditOpen, setIsAIEditOpen] = useState(false);
   const [aiInstruction, setAiInstruction] = useState("");
   const [isAIEditing, setIsAIEditing] = useState(false);
@@ -569,7 +570,7 @@ export function TaskItem({
             className="overflow-hidden pl-4 pr-0 border-l-2 border-foreground/10 ml-2"
           >
             <div className="flex flex-col gap-1.5">
-              {subTasks.map((subTask) => (
+              {(showAllSubtasks || subTasks.length < 7 ? subTasks : subTasks.slice(0, 6)).map((subTask) => (
                 <div key={subTask.id} className="relative">
                   <TaskItem
                     task={subTask}
@@ -585,6 +586,26 @@ export function TaskItem({
                   <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />
                 </div>
               ))}
+              {subTasks.length >= 7 && !showAllSubtasks && (
+                <motion.button
+                  onClick={() => setShowAllSubtasks(true)}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors py-1 px-2 rounded-lg hover:bg-secondary/50 text-left"
+                  whileTap={{ scale: 0.97 }}
+                  transition={springTransition}
+                >
+                  残り{subTasks.length - 6}個を表示
+                </motion.button>
+              )}
+              {subTasks.length >= 7 && showAllSubtasks && (
+                <motion.button
+                  onClick={() => setShowAllSubtasks(false)}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors py-1 px-2 rounded-lg hover:bg-secondary/50 text-left"
+                  whileTap={{ scale: 0.97 }}
+                  transition={springTransition}
+                >
+                  折りたたむ
+                </motion.button>
+              )}
             </div>
           </motion.div>
         )}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -90,23 +90,36 @@ export function useTasks() {
         .eq("id", id);
 
       // サブタスクを done にした時、全兄弟が done/canceled なら親も自動完了
+      // 注: siblings は setTasks 前の tasks を参照するため、対象タスク自身はまだ "done" でない状態で評価される
       if (newStatus === "done" && task.parentId) {
         const siblings = tasks.filter(
           (t) => t.parentId === task.parentId && t.id !== id
         );
-        const allSiblingsDone = siblings.every(
-          (t) => t.status === "done" || t.status === "canceled"
-        );
-        if (allSiblingsDone) {
-          setTasks((prev) =>
-            prev.map((t) =>
-              t.id === task.parentId ? { ...t, status: "done" } : t
-            )
+        // サブタスクが1つだけの場合（siblings が空）は自動完了しない
+        if (siblings.length > 0) {
+          const allSiblingsDone = siblings.every(
+            (t) => t.status === "done" || t.status === "canceled"
           );
-          await supabase
-            .from("tasks")
-            .update({ status: "done" })
-            .eq("id", task.parentId);
+          if (allSiblingsDone) {
+            const parentPrevStatus = tasks.find((t) => t.id === task.parentId)?.status;
+            setTasks((prev) =>
+              prev.map((t) =>
+                t.id === task.parentId ? { ...t, status: "done" } : t
+              )
+            );
+            const { error: parentError } = await supabase
+              .from("tasks")
+              .update({ status: "done" })
+              .eq("id", task.parentId);
+            if (parentError && parentPrevStatus !== undefined) {
+              // ロールバック: 親タスクの更新が失敗した場合は元のステータスに戻す
+              setTasks((prev) =>
+                prev.map((t) =>
+                  t.id === task.parentId ? { ...t, status: parentPrevStatus } : t
+                )
+              );
+            }
+          }
         }
       }
     },

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -88,6 +88,27 @@ export function useTasks() {
         .from("tasks")
         .update({ status: newStatus })
         .eq("id", id);
+
+      // サブタスクを done にした時、全兄弟が done/canceled なら親も自動完了
+      if (newStatus === "done" && task.parentId) {
+        const siblings = tasks.filter(
+          (t) => t.parentId === task.parentId && t.id !== id
+        );
+        const allSiblingsDone = siblings.every(
+          (t) => t.status === "done" || t.status === "canceled"
+        );
+        if (allSiblingsDone) {
+          setTasks((prev) =>
+            prev.map((t) =>
+              t.id === task.parentId ? { ...t, status: "done" } : t
+            )
+          );
+          await supabase
+            .from("tasks")
+            .update({ status: "done" })
+            .eq("id", task.parentId);
+        }
+      }
     },
     [tasks, supabase]
   );

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -29,7 +29,7 @@ export const RawTaskSchema = z.object({
 });
 
 export const BreakdownTaskSchema = z.object({
-  title: z.string(),
+  title: z.string().max(20),
   estimatedTime: z.string().optional(),
   actionLink: z.string().optional(),
 });


### PR DESCRIPTION
## 概要

AI によるサブタスク分割の品質を 3 点改善しました。

## 実装内容

### 1. breakdown API プロンプト改善（3 ルート共通）
- 個数固定（3〜5 個）をやめ、タスクの規模に応じた全ステップを生成するよう変更
- タイトルを 20 文字以内の簡潔な動詞句に限定するルールを追加

対象: `src/app/api/breakdown/route.ts`, `src/app/api/breakdown/edit/route.ts`, `src/app/api/breakdown/edit/single/route.ts`

### 2. 親タスク自動完了（`useTasks.ts`）
- `toggleTask` でサブタスクを done にした際、全兄弟サブタスクが done/canceled なら親タスクも自動で done に更新
- `changeTaskStatus` からは発火しない（UI 上の明示操作を妨げないため）

### 3. サブタスク折りたたみ（`TaskItem.tsx`）
- サブタスクが 7 件以上の場合、初期表示は 6 件に限定
- 「残りN個を表示」ボタンで全件展開、「折りたたむ」で戻せる

## 関連
Closes #16
実装計画: #18

🤖 Generated with Claude Code Scheduled Task
