### PR TITLE
エラー表示をユーザーフレンドリーにする

### DIFF
--- a/src/app/api/breakdown/edit/route.ts
+++ b/src/app/api/breakdown/edit/route.ts
@@ -43,14 +43,14 @@ export async function POST(req: Request) {
     const parsed = EditBreakdownRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { parentPrompt, currentTasks, instruction } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -80,13 +80,17 @@ ${currentTasksText}
       const breakdown = BreakdownResponseSchema.parse(JSON.parse(jsonString));
       return NextResponse.json(breakdown);
     } catch {
-      return NextResponse.json({ error: "Failed to parse AI response" }, { status: 502 });
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
     }
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in breakdown edit API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to edit breakdown" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to edit breakdown", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/breakdown/edit/single/route.ts
+++ b/src/app/api/breakdown/edit/single/route.ts
@@ -51,14 +51,14 @@ export async function POST(req: Request) {
     const parsed = SingleEditRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { parentPrompt, targetTask, allCurrentTasks, instruction } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -93,13 +93,17 @@ ${tasksText}
       const response = SingleEditResponseSchema.parse(JSON.parse(jsonString));
       return NextResponse.json(response);
     } catch {
-      return NextResponse.json({ error: "Failed to parse AI response" }, { status: 502 });
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
     }
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in single subtask edit API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to edit subtask" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to edit subtask", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/breakdown/route.ts
+++ b/src/app/api/breakdown/route.ts
@@ -46,14 +46,14 @@ export async function POST(req: Request) {
     const parsed = BreakdownRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { prompt } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -72,13 +72,17 @@ export async function POST(req: Request) {
       const breakdown = BreakdownResponseSchema.parse(JSON.parse(jsonString));
       return NextResponse.json(breakdown);
     } catch {
-      return NextResponse.json({ error: "Failed to parse AI response" }, { status: 502 });
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
     }
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in breakdown API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to process task" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to process task", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/compass/chat/route.ts
+++ b/src/app/api/compass/chat/route.ts
@@ -47,14 +47,14 @@ export async function POST(req: Request) {
     const parsed = ChatRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { messages } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -77,9 +77,13 @@ export async function POST(req: Request) {
     return NextResponse.json({ message: text });
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in compass chat API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to process chat" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to process chat", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/compass/philosophy/route.ts
+++ b/src/app/api/compass/philosophy/route.ts
@@ -43,14 +43,14 @@ export async function POST(req: Request) {
     const parsed = ChatRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { messages } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -73,13 +73,17 @@ export async function POST(req: Request) {
       const philosophy = PhilosophySchema.parse(JSON.parse(jsonString));
       return NextResponse.json(philosophy);
     } catch {
-      return NextResponse.json({ error: "Failed to parse AI response" }, { status: 502 });
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
     }
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in philosophy generation API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to generate philosophy" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to generate philosophy", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/compass/roadmap/edit/route.ts
+++ b/src/app/api/compass/roadmap/edit/route.ts
@@ -46,14 +46,14 @@ export async function POST(req: Request) {
     const parsed = EditRoadmapRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { goal, timeframe, currentMilestones, instruction } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -86,13 +86,17 @@ ${instruction.trim()}`;
       const roadmap = RoadmapResponseSchema.parse(JSON.parse(jsonString));
       return NextResponse.json(roadmap);
     } catch {
-      return NextResponse.json({ error: "Failed to parse AI response" }, { status: 502 });
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
     }
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in roadmap edit API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to edit roadmap" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to edit roadmap", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/app/api/compass/roadmap/route.ts
+++ b/src/app/api/compass/roadmap/route.ts
@@ -38,14 +38,14 @@ export async function POST(req: Request) {
     const parsed = RoadmapRequestSchema.safeParse(body);
 
     if (!parsed.success) {
-      return NextResponse.json({ error: "Invalid request", details: parsed.error.flatten() }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR", details: parsed.error.flatten() }, { status: 400 });
     }
 
     const { goal, timeframe, philosophy } = parsed.data;
 
     const apiKey = process.env.GEMINI_API_KEY || process.env.GOOGLE_GENERATIVE_AI_API_KEY;
     if (!apiKey) {
-      return NextResponse.json({ error: "API key not configured" }, { status: 500 });
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
@@ -70,13 +70,17 @@ export async function POST(req: Request) {
       const roadmap = RoadmapResponseSchema.parse(JSON.parse(jsonString));
       return NextResponse.json(roadmap);
     } catch {
-      return NextResponse.json({ error: "Failed to parse AI response" }, { status: 502 });
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
     }
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
-      return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
     }
     console.error("Error in roadmap generation API:", getErrorMessage(error));
-    return NextResponse.json({ error: "Failed to generate roadmap" }, { status: 500 });
+    return NextResponse.json({ error: "Failed to generate roadmap", errorCode: "INTERNAL_ERROR" }, { status: 500 });
   }
 }

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -6,6 +6,7 @@ import { MapPin, ArrowRight, Check, Pencil, Trash2, Plus, X, Wand2, Send, Loader
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
 import { toast } from "sonner";
+import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage } from "@/lib/errors";
 import type { Milestone, Roadmap } from "@/hooks/useCompass";
 
 interface RoadmapTimelineProps {
@@ -201,7 +202,11 @@ export function RoadmapTimeline({
       setIsAIEditOpen(false);
       setAiInstruction("");
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : "AI修正に失敗しました");
+      if (error instanceof ApiError) {
+        toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
+      } else {
+        toast.error(getNetworkErrorMessage());
+      }
     } finally {
       setIsAIEditing(false);
     }

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -6,7 +6,7 @@ import { MapPin, ArrowRight, Check, Pencil, Trash2, Plus, X, Wand2, Send, Loader
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
 import { toast } from "sonner";
-import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage } from "@/lib/errors";
+import { ApiError, getUserFriendlyErrorMessage, NETWORK_ERROR_MESSAGE } from "@/lib/errors";
 import type { Milestone, Roadmap } from "@/hooks/useCompass";
 
 interface RoadmapTimelineProps {
@@ -205,7 +205,7 @@ export function RoadmapTimeline({
       if (error instanceof ApiError) {
         toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
       } else {
-        toast.error(getNetworkErrorMessage());
+        toast.error(NETWORK_ERROR_MESSAGE);
       }
     } finally {
       setIsAIEditing(false);

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
 import { formatScheduleBadge } from "@/lib/date";
 import { toast } from "sonner";
+import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage } from "@/lib/errors";
 
 export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'canceled';
 
@@ -108,7 +109,11 @@ export function TaskItem({
       setIsAIEditOpen(false);
       setAiInstruction("");
     } catch (error: unknown) {
-      toast.error(error instanceof Error ? error.message : "AI修正に失敗しました");
+      if (error instanceof ApiError) {
+        toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
+      } else {
+        toast.error(getNetworkErrorMessage());
+      }
     } finally {
       setIsAIEditing(false);
     }

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
 import { formatScheduleBadge } from "@/lib/date";
 import { toast } from "sonner";
-import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage } from "@/lib/errors";
+import { ApiError, getUserFriendlyErrorMessage, NETWORK_ERROR_MESSAGE } from "@/lib/errors";
 
 export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'canceled';
 
@@ -112,7 +112,7 @@ export function TaskItem({
       if (error instanceof ApiError) {
         toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
       } else {
-        toast.error(getNetworkErrorMessage());
+        toast.error(NETWORK_ERROR_MESSAGE);
       }
     } finally {
       setIsAIEditing(false);

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/client";
 import { toast } from "sonner";
-import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage, parseApiError } from "@/lib/errors";
+import { ApiError, getUserFriendlyErrorMessage, NETWORK_ERROR_MESSAGE, parseApiError } from "@/lib/errors";
 
 export interface ChatMessage {
   id: string;
@@ -315,7 +315,7 @@ export function useCompass() {
         if (error instanceof ApiError) {
           toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
         } else {
-          toast.error(getNetworkErrorMessage());
+          toast.error(NETWORK_ERROR_MESSAGE);
         }
       } finally {
         setIsChatLoading(false);
@@ -469,7 +469,7 @@ export function useCompass() {
       if (error instanceof ApiError) {
         toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
       } else {
-        toast.error(getNetworkErrorMessage());
+        toast.error(NETWORK_ERROR_MESSAGE);
       }
     } finally {
       setIsPhilosophyLoading(false);
@@ -586,7 +586,7 @@ export function useCompass() {
         if (error instanceof ApiError) {
           toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
         } else {
-          toast.error(getNetworkErrorMessage());
+          toast.error(NETWORK_ERROR_MESSAGE);
         }
         return null;
       } finally {

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -8,6 +8,8 @@ import {
   ChatResponseSchema,
 } from "@/lib/schemas";
 import { createClient } from "@/lib/supabase/client";
+import { toast } from "sonner";
+import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage, parseApiError } from "@/lib/errors";
 
 export interface ChatMessage {
   id: string;
@@ -283,7 +285,7 @@ export function useCompass() {
           }),
         });
 
-        if (!response.ok) throw new Error(`Chat API error: ${response.status}`);
+        if (!response.ok) throw await parseApiError(response);
 
         const parsed = ChatResponseSchema.safeParse(await response.json());
         if (parsed.success) {
@@ -308,8 +310,13 @@ export function useCompass() {
             });
           }
         }
-      } catch (error) {
+      } catch (error: unknown) {
         console.error("Failed to send chat message:", error);
+        if (error instanceof ApiError) {
+          toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
+        } else {
+          toast.error(getNetworkErrorMessage());
+        }
       } finally {
         setIsChatLoading(false);
       }
@@ -356,7 +363,7 @@ export function useCompass() {
         }),
       });
 
-      if (!response.ok) throw new Error(`Philosophy API error: ${response.status}`);
+      if (!response.ok) throw await parseApiError(response);
 
       const parsed = PhilosophySchema.safeParse(await response.json());
       if (!parsed.success) return;
@@ -457,8 +464,13 @@ export function useCompass() {
           )
         );
       }
-    } catch (error) {
+    } catch (error: unknown) {
       console.error("Failed to generate philosophy:", error);
+      if (error instanceof ApiError) {
+        toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
+      } else {
+        toast.error(getNetworkErrorMessage());
+      }
     } finally {
       setIsPhilosophyLoading(false);
     }
@@ -533,7 +545,7 @@ export function useCompass() {
           body: JSON.stringify({ goal, timeframe, philosophy: philosophyPayload }),
         });
 
-        if (!response.ok) throw new Error(`Roadmap API error: ${response.status}`);
+        if (!response.ok) throw await parseApiError(response);
 
         const parsed = RoadmapResponseSchema.safeParse(await response.json());
         if (!parsed.success) return null;
@@ -569,8 +581,13 @@ export function useCompass() {
         const newRoadmap = rowToRoadmap(roadmapRow, milestones);
         setRoadmaps((prev) => [newRoadmap, ...prev]);
         return newRoadmap.id;
-      } catch (error) {
+      } catch (error: unknown) {
         console.error("Failed to generate roadmap:", error);
+        if (error instanceof ApiError) {
+          toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
+        } else {
+          toast.error(getNetworkErrorMessage());
+        }
         return null;
       } finally {
         setIsRoadmapLoading(false);
@@ -727,11 +744,11 @@ export function useCompass() {
       });
 
       if (!response.ok) {
-        throw new Error(`Edit roadmap API error: ${response.status}`);
+        throw await parseApiError(response);
       }
 
       const parsed = RoadmapResponseSchema.safeParse(await response.json());
-      if (!parsed.success) throw new Error("Failed to parse AI response");
+      if (!parsed.success) throw new ApiError(502, "AI_PARSE_FAILURE");
 
       // INSERT先にしてからDELETE（INSERT失敗時のデータ消失を防ぐ）
       const { data: newMilestoneRows } = await supabase

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -8,7 +8,7 @@ import { getTodayStr } from "@/lib/date";
 import { createClient } from "@/lib/supabase/client";
 import { z } from "zod";
 import { toast } from "sonner";
-import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage, parseApiError } from "@/lib/errors";
+import { ApiError, getUserFriendlyErrorMessage, NETWORK_ERROR_MESSAGE, parseApiError } from "@/lib/errors";
 
 const SingleEditResponseSchema = z.object({ task: BreakdownTaskSchema });
 
@@ -266,9 +266,7 @@ export function useTasks() {
         });
 
         if (!response.ok) {
-          const err = await parseApiError(response);
-          toast.error(getUserFriendlyErrorMessage(err.status, err.errorCode));
-          return null;
+          throw await parseApiError(response);
         }
 
         const parsed = BreakdownResponseSchema.safeParse(await response.json());
@@ -332,7 +330,11 @@ export function useTasks() {
         return parentId;
       } catch (error: unknown) {
         console.error("Failed to breakdown task:", error);
-        toast.error(getNetworkErrorMessage());
+        if (error instanceof ApiError) {
+          toast.error(getUserFriendlyErrorMessage(error.status, error.errorCode));
+        } else {
+          toast.error(NETWORK_ERROR_MESSAGE);
+        }
         return null;
       } finally {
         setIsLoading(false);

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -7,6 +7,8 @@ import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
 import { getTodayStr } from "@/lib/date";
 import { createClient } from "@/lib/supabase/client";
 import { z } from "zod";
+import { toast } from "sonner";
+import { ApiError, getUserFriendlyErrorMessage, getNetworkErrorMessage, parseApiError } from "@/lib/errors";
 
 const SingleEditResponseSchema = z.object({ task: BreakdownTaskSchema });
 
@@ -264,7 +266,9 @@ export function useTasks() {
         });
 
         if (!response.ok) {
-          throw new Error(`Breakdown API error: ${response.status}`);
+          const err = await parseApiError(response);
+          toast.error(getUserFriendlyErrorMessage(err.status, err.errorCode));
+          return null;
         }
 
         const parsed = BreakdownResponseSchema.safeParse(await response.json());
@@ -326,8 +330,9 @@ export function useTasks() {
 
         setTasks((prev) => [parentTask, ...newTasks, ...prev]);
         return parentId;
-      } catch (error) {
+      } catch (error: unknown) {
         console.error("Failed to breakdown task:", error);
+        toast.error(getNetworkErrorMessage());
         return null;
       } finally {
         setIsLoading(false);
@@ -367,11 +372,11 @@ export function useTasks() {
         });
 
         if (!response.ok) {
-          throw new Error(`Edit breakdown API error: ${response.status}`);
+          throw await parseApiError(response);
         }
 
         const parsed = SingleEditResponseSchema.safeParse(await response.json());
-        if (!parsed.success) throw new Error("Failed to parse AI response");
+        if (!parsed.success) throw new ApiError(502, "AI_PARSE_FAILURE");
 
         const updated = parsed.data.task;
 
@@ -412,11 +417,11 @@ export function useTasks() {
       });
 
       if (!response.ok) {
-        throw new Error(`Edit breakdown API error: ${response.status}`);
+        throw await parseApiError(response);
       }
 
       const parsed = BreakdownResponseSchema.safeParse(await response.json());
-      if (!parsed.success) throw new Error("Failed to parse AI response");
+      if (!parsed.success) throw new ApiError(502, "AI_PARSE_FAILURE");
 
       const {
         data: { user },

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -32,8 +32,11 @@ export function getUserFriendlyErrorMessage(
   if (errorCode === "API_KEY_MISSING") {
     return "サービスの設定に問題が発生しました。しばらく時間をおいてお試しください。";
   }
-  if (status === 429 || status === 503 || errorCode === "RATE_LIMIT") {
+  if (status === 429 || errorCode === "RATE_LIMIT") {
     return "AIが混み合っています。少し待ってから再度お試しください。";
+  }
+  if (status === 503) {
+    return "AIサービスが一時的に利用できません。しばらく時間をおいてお試しください。";
   }
   if (status === 502 || errorCode === "AI_PARSE_FAILURE") {
     return "AIの応答を解析できませんでした。もう一度お試しください。";
@@ -44,9 +47,7 @@ export function getUserFriendlyErrorMessage(
   return "予期しないエラーが発生しました。しばらく時間をおいてお試しください。";
 }
 
-export function getNetworkErrorMessage(): string {
-  return "ネットワーク接続を確認してください。";
-}
+export const NETWORK_ERROR_MESSAGE = "ネットワーク接続を確認してください。";
 
 export async function parseApiError(response: Response): Promise<ApiError> {
   const body: unknown = await response.json().catch(() => ({}));

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+export const ErrorCodeSchema = z.enum([
+  "API_KEY_MISSING",
+  "RATE_LIMIT",
+  "AI_PARSE_FAILURE",
+  "VALIDATION_ERROR",
+  "INTERNAL_ERROR",
+]);
+
+export type ErrorCode = z.infer<typeof ErrorCodeSchema>;
+
+export const ApiErrorResponseSchema = z.object({
+  error: z.string(),
+  errorCode: ErrorCodeSchema.optional(),
+});
+
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly errorCode?: ErrorCode
+  ) {
+    super(`API error ${status}`);
+    this.name = "ApiError";
+  }
+}
+
+export function getUserFriendlyErrorMessage(
+  status: number,
+  errorCode?: ErrorCode
+): string {
+  if (errorCode === "API_KEY_MISSING") {
+    return "サービスの設定に問題が発生しました。しばらく時間をおいてお試しください。";
+  }
+  if (status === 429 || status === 503 || errorCode === "RATE_LIMIT") {
+    return "AIが混み合っています。少し待ってから再度お試しください。";
+  }
+  if (status === 502 || errorCode === "AI_PARSE_FAILURE") {
+    return "AIの応答を解析できませんでした。もう一度お試しください。";
+  }
+  if (status === 400 || errorCode === "VALIDATION_ERROR") {
+    return "入力内容に問題があります。タスクの内容を確認してください。";
+  }
+  return "予期しないエラーが発生しました。しばらく時間をおいてお試しください。";
+}
+
+export function getNetworkErrorMessage(): string {
+  return "ネットワーク接続を確認してください。";
+}
+
+export async function parseApiError(response: Response): Promise<ApiError> {
+  const body: unknown = await response.json().catch(() => ({}));
+  const parsed = ApiErrorResponseSchema.safeParse(body);
+  const errorCode = parsed.success ? parsed.data.errorCode : undefined;
+  return new ApiError(response.status, errorCode);
+}


### PR DESCRIPTION
## 概要

APIエラー発生時にステータスコードや内部エラーメッセージをユーザーに見せる問題を解決し、状況に応じた日本語のユーザーフレンドリーなトースト通知を表示するよう改善。

## 実装内容

### `src/lib/errors.ts` (新規作成)
- `ErrorCode` 型 (`API_KEY_MISSING` / `RATE_LIMIT` / `AI_PARSE_FAILURE` / `VALIDATION_ERROR` / `INTERNAL_ERROR`)
- `ApiError` クラス: status と errorCode を持つカスタムエラー
- `getUserFriendlyErrorMessage(status, errorCode?)`: HTTPステータスとエラーコードから日本語メッセージを返す
- `parseApiError(response)`: レスポンスから `errorCode` を安全にパースして `ApiError` を返す

### 全7本の APIルートに `errorCode` フィールドを追加
- `breakdown/route.ts`, `breakdown/edit/route.ts`, `breakdown/edit/single/route.ts`
- `compass/chat/route.ts`, `compass/philosophy/route.ts`, `compass/roadmap/route.ts`, `compass/roadmap/edit/route.ts`
- Gemini API のレートリミット(429/quota/rate limit)を検出し、429 + `RATE_LIMIT` errorCode で返すよう実装

### `useTasks.ts` のエラーハンドリング改善
- `breakdownTask`: `!response.ok` 時に `parseApiError` + `getUserFriendlyErrorMessage` でトースト表示してから `null` を返す。fetch 失敗時はネットワークエラーメッセージを表示
- `editBreakdown`: `!response.ok` 時に `ApiError` をスロー。parse失敗時も `ApiError(502)` をスロー

### `useCompass.ts` のエラーハンドリング改善
- `sendMessage` / `generatePhilosophy` / `generateRoadmap`: catch ブロックで `ApiError` 判定し、適切なトーストを表示
- `editRoadmapWithAI`: `ApiError` をスローして呼び出し元でハンドル

### `TaskItem.tsx` / `RoadmapTimeline.tsx` の修正
- catch ブロックを `ApiError instanceof` チェックに変更: エラーコードベースの日本語メッセージを表示。非 API エラー（fetch自体の失敗等）はネットワークエラーメッセージを表示

## 関連
Closes #17
実装計画: #19

🤖 Generated with Claude Code Scheduled Task
