### PR TITLE
AIによるサブタスク分割の精度をあげる

### DIFF
--- a/src/app/api/breakdown/edit/route.ts
+++ b/src/app/api/breakdown/edit/route.ts
@@ -14,17 +14,20 @@ const systemPrompt = `
 You are an expert AI task breakdown engine ("Magic Breakdown").
 The user has an existing task breakdown and wants to modify it based on their instruction.
 You will receive the original goal, the current subtasks, and an edit instruction.
-Apply the edit instruction to produce an updated list of 3 to 7 highly actionable, specific sub-tasks.
+Apply the edit instruction to produce an updated list of highly actionable, specific sub-tasks covering all steps needed to complete the goal.
+Determine the appropriate number of sub-tasks yourself based on the complexity — do NOT use a fixed count.
 Keep tasks not affected by the instruction as they are.
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).
 The task titles and any generated text must be in natural Japanese.
 
+IMPORTANT: Each task title must be 20 characters or fewer. Use concise verb phrases (e.g. "材料を買う", "動画を見る").
+
 Respond STRICTLY with a JSON object matching this schema, without markdown formatting:
 {
   "tasks": [
     {
-      "title": "動詞で始まる具体的で行動可能なステップ（日本語）",
+      "title": "20文字以内の動詞句（日本語）",
       "estimatedTime": "15分",
       "actionLink": "https://example.com/useful-link"
     }

--- a/src/app/api/breakdown/edit/single/route.ts
+++ b/src/app/api/breakdown/edit/single/route.ts
@@ -30,10 +30,12 @@ Take into account the other sub-tasks so the revised task does not duplicate or 
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).
 
+IMPORTANT: The task title must be 20 characters or fewer. Use a concise verb phrase (e.g. "材料を買う", "動画を見る").
+
 Respond STRICTLY with a JSON object, without markdown formatting:
 {
   "task": {
-    "title": "動詞で始まる具体的で行動可能なステップ（日本語）",
+    "title": "20文字以内の動詞句（日本語）",
     "estimatedTime": "15分",
     "actionLink": "https://example.com/useful-link"
   }

--- a/src/app/api/breakdown/route.ts
+++ b/src/app/api/breakdown/route.ts
@@ -11,17 +11,20 @@ const BreakdownRequestSchema = z.object({
 const systemPrompt = `
 You are an expert AI task breakdown engine ("Magic Breakdown").
 The user will give you a vague task, goal, or idea.
-Your job is to break it down into 3 to 5 highly actionable, specific, and friction-less sub-tasks.
+Your job is to break it down into all the highly actionable, specific, and friction-less sub-tasks needed to COMPLETE the goal from start to finish.
+Determine the appropriate number of sub-tasks yourself based on the complexity of the goal — simple tasks may need 3 steps, complex ones may need 10 or more. Do NOT limit yourself to a fixed count.
 Think about reducing the barrier to execution.
 
 CRITICAL REQUIREMENT: YOU MUST RESPOND ENTIRELY IN JAPANESE (日本語).
 The task titles and any generated text must be in natural Japanese.
 
+IMPORTANT: Each task title must be 20 characters or fewer. Use concise verb phrases (e.g. "材料を買う", "動画を見る").
+
 Respond STRICTLY with a JSON object matching this schema, without markdown formatting if possible, just the raw JSON:
 {
   "tasks": [
     {
-      "title": "動詞で始まる具体的で行動可能なステップ（日本語）",
+      "title": "20文字以内の動詞句（日本語）",
       "estimatedTime": "15分",
       "actionLink": "https://example.com/useful-link"
     }

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -68,6 +68,7 @@ export function TaskItem({
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(task.title);
   const [isExpanded, setIsExpanded] = useState(false);
+  const [showAllSubtasks, setShowAllSubtasks] = useState(false);
   const [isAIEditOpen, setIsAIEditOpen] = useState(false);
   const [aiInstruction, setAiInstruction] = useState("");
   const [isAIEditing, setIsAIEditing] = useState(false);
@@ -569,7 +570,10 @@ export function TaskItem({
             className="overflow-hidden pl-4 pr-0 border-l-2 border-foreground/10 ml-2"
           >
             <div className="flex flex-col gap-1.5">
-              {subTasks.map((subTask) => (
+              {(subTasks.length >= 7 && !showAllSubtasks
+                ? subTasks.slice(0, 6)
+                : subTasks
+              ).map((subTask) => (
                 <div key={subTask.id} className="relative">
                   <TaskItem
                     task={subTask}
@@ -585,6 +589,16 @@ export function TaskItem({
                   <div className="absolute left-[-26px] top-1/2 w-4 h-px bg-foreground/10" />
                 </div>
               ))}
+              {subTasks.length >= 7 && (
+                <button
+                  onClick={() => setShowAllSubtasks((v) => !v)}
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors duration-200 py-1 text-left"
+                >
+                  {showAllSubtasks
+                    ? "折りたたむ"
+                    : `残り${subTasks.length - 6}個を表示`}
+                </button>
+              )}
             </div>
           </motion.div>
         )}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -80,14 +80,30 @@ export function useTasks() {
       if (!task) return;
       const newStatus: TaskStatus = task.status === "done" ? "todo" : "done";
 
+      // Check if all siblings are done/canceled → auto-complete parent
+      let parentToComplete: string | undefined;
+      if (newStatus === "done" && task.parentId) {
+        const siblings = tasks.filter((t) => t.parentId === task.parentId && t.id !== id);
+        const allDone = siblings.every(
+          (t) => t.status === "done" || t.status === "canceled"
+        );
+        if (allDone) {
+          parentToComplete = task.parentId;
+        }
+      }
+
       setTasks((prev) =>
-        prev.map((t) => (t.id === id ? { ...t, status: newStatus } : t))
+        prev.map((t) => {
+          if (t.id === id) return { ...t, status: newStatus };
+          if (parentToComplete && t.id === parentToComplete) return { ...t, status: "done" as TaskStatus };
+          return t;
+        })
       );
 
-      await supabase
-        .from("tasks")
-        .update({ status: newStatus })
-        .eq("id", id);
+      await supabase.from("tasks").update({ status: newStatus }).eq("id", id);
+      if (parentToComplete) {
+        await supabase.from("tasks").update({ status: "done" }).eq("id", parentToComplete);
+      }
     },
     [tasks, supabase]
   );


### PR DESCRIPTION
## 概要

Issue #16 で報告されたAIタスク分割の3つの問題（全サブタスク完了後も親タスクが完了しない・タイトルが長い・サブタスク数が固定）を修正し、ボーナス改善としてサブタスク折りたたみUIを追加。

## 実装内容

### 1. 親タスクの自動完了 (`useTasks.ts`)
- `toggleTask` にサブタスク完了時の兄弟チェックロジックを追加
- 全兄弟サブタスクが `done` または `canceled` になった時点で親タスクを自動的に `done` へ更新
- `changeTaskStatus`（手動ステータス変更）からは発火しない設計を維持

### 2. AIプロンプト改善（3ルート共通）
- `breakdown/route.ts`: 固定数（3〜5個）を廃止 → タスクの複雑度に応じてAIが適切な数を判断
- `breakdown/edit/route.ts`: 固定数（3〜7個）を廃止 → 同上
- 全3ルートにタイトル20文字以内の制約を追加（「材料を買う」のような簡潔な動詞句）

### 3. サブタスク折りたたみUI (`TaskItem.tsx`)
- サブタスクが7個以上の場合、最初の6個のみ表示
- 「残りN個を表示」ボタンでアコーディオン展開
- `showAllSubtasks` state で管理、「折りたたむ」ボタンで元に戻す

## 関連
Closes #16
実装計画: #25

🤖 Generated with Claude Code Scheduled Task