### PR TITLE
価値観発掘

### DIFF
--- a/src/app/api/compass/chat/route.ts
+++ b/src/app/api/compass/chat/route.ts
@@ -39,6 +39,13 @@ const systemPrompt = `
 - ユーザーが引き続き話しかけてきた場合は、まだ触れていない別のテーマ・角度から新たな質問を1つだけする。
 - すでに深掘りした内容は繰り返さない。新しい切り口（例：「起源」「反転質問」「他者との関係」）を選ぶ。
 - 2ターンごとに、改めて「これだけ話せましたね。哲学を生成してみませんか？」と促す。
+
+## 返答候補の出力（必須）
+毎回の返答の末尾に、必ず以下の形式の行を追加してください：
+SUGGESTIONS_JSON:["候補1","候補2","候補3"]
+- ユーザーが次に言いそうな自然な返答を2〜3個、短く（20文字以内）日本語で書く。
+- この行はユーザーには表示されないため、会話の流れを壊さない内容にする。
+- JSON形式を厳守し、ダブルクォートを使うこと。
 `;
 
 export async function POST(req: Request) {
@@ -72,9 +79,27 @@ export async function POST(req: Request) {
     const chat = model.startChat({ history });
 
     const result = await chat.sendMessage(lastMessage.content);
-    const text = result.response.text();
+    const rawText = result.response.text();
 
-    return NextResponse.json({ message: text });
+    const lines = rawText.split("\n");
+    const suggestionLineIndex = lines.findLastIndex((l: string) => l.startsWith("SUGGESTIONS_JSON:"));
+    let suggestions: string[] | undefined;
+    let message = rawText;
+
+    if (suggestionLineIndex !== -1) {
+      const jsonPart = lines[suggestionLineIndex].slice("SUGGESTIONS_JSON:".length).trim();
+      try {
+        const parsed: unknown = JSON.parse(jsonPart);
+        if (Array.isArray(parsed) && parsed.every((s) => typeof s === "string")) {
+          suggestions = parsed;
+        }
+      } catch {
+        // fallback: no suggestions
+      }
+      message = lines.slice(0, suggestionLineIndex).join("\n").trimEnd();
+    }
+
+    return NextResponse.json({ message, suggestions });
   } catch (error: unknown) {
     if (error instanceof z.ZodError) {
       return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });

--- a/src/app/compass/page.tsx
+++ b/src/app/compass/page.tsx
@@ -33,6 +33,7 @@ export default function CompassPage() {
     sendMessage,
     isChatLoading,
     resetChat,
+    currentSuggestions,
     // Roadmap
     roadmaps,
     generateRoadmap,
@@ -144,6 +145,7 @@ export default function CompassPage() {
                   onResetChat={resetChat}
                   isChatLoading={isChatLoading}
                   isPhilosophyLoading={isPhilosophyLoading}
+                  currentSuggestions={currentSuggestions}
                 />
               </div>
 

--- a/src/components/features/compass/PhilosophyChat.tsx
+++ b/src/components/features/compass/PhilosophyChat.tsx
@@ -28,7 +28,7 @@ const STARTER_CHIPS = [
   "時間を忘れて没頭できることがある",
   "自分の強みについて考えたい",
   "人生でやりたいことを整理したい",
-];
+] as const;
 
 const messageVariants = {
   hidden: { opacity: 0, y: 12, scale: 0.96 },
@@ -88,10 +88,10 @@ export function PhilosophyChat({
     onSendMessage(text);
   };
 
-  const canGeneratePhilosophy = messages.length >= 4 && !isChatLoading;
-
-  const remainingForPhilosophy = Math.max(0, 4 - messages.length);
-  const showProgressHint = messages.length < 4;
+  const userMessageCount = messages.filter((m) => m.role === "user").length;
+  const canGeneratePhilosophy = userMessageCount >= 4 && !isChatLoading;
+  const remainingForPhilosophy = Math.max(0, 4 - userMessageCount);
+  const showProgressHint = userMessageCount < 4;
 
   // Show quick-reply chips only after last AI message, not while loading
   const lastMessage = messages[messages.length - 1];
@@ -155,7 +155,7 @@ export function PhilosophyChat({
               AIコーチとの対話で、あなたの価値観を発掘しましょう。
             </p>
             {/* Starter chips */}
-            <div className="flex flex-wrap justify-center gap-2 max-w-sm">
+            <div className="flex flex-wrap justify-center gap-2 max-w-sm mb-3">
               {STARTER_CHIPS.map((chip, i) => (
                 <motion.button
                   key={chip}
@@ -166,7 +166,6 @@ export function PhilosophyChat({
                   onClick={() => handleChipClick(chip)}
                   whileHover={{ y: -2, scale: 1.02 }}
                   whileTap={{ scale: 0.96 }}
-                  transition={springTransition}
                   className="px-3 py-2 rounded-xl text-sm bg-compass-subtle text-compass border border-compass-border hover:bg-compass/15 transition-colors"
                 >
                   {chip}
@@ -231,7 +230,7 @@ export function PhilosophyChat({
                   >
                     {currentSuggestions.map((suggestion, i) => (
                       <motion.button
-                        key={`${suggestion}-${i}`}
+                        key={suggestion}
                         custom={i}
                         variants={chipVariants}
                         initial="hidden"
@@ -239,7 +238,6 @@ export function PhilosophyChat({
                         onClick={() => handleChipClick(suggestion)}
                         whileHover={{ y: -1, scale: 1.02 }}
                         whileTap={{ scale: 0.96 }}
-                        transition={springTransition}
                         className="px-3 py-1.5 rounded-xl text-xs bg-compass-subtle text-compass border border-compass-border hover:bg-compass/15 transition-colors"
                       >
                         {suggestion}
@@ -270,30 +268,33 @@ export function PhilosophyChat({
         )}
       </div>
 
-      {/* Progress hint */}
-      <AnimatePresence>
-        {showProgressHint && messages.length > 0 && (
-          <motion.p
-            initial={{ opacity: 0, y: 4 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -4 }}
-            transition={springTransition}
-            className="text-xs text-muted-foreground/70 text-center mb-2"
-          >
-            あと{remainingForPhilosophy}回で哲学を生成できます
-          </motion.p>
-        )}
-      </AnimatePresence>
+      {/* Free input hint + progress hint */}
+      <div className="flex flex-col items-center gap-1 mb-2">
+        <p className="text-xs text-muted-foreground/50">または、入力欄から自由に話しかけてください</p>
+        <AnimatePresence>
+          {showProgressHint && messages.length > 0 && (
+            <motion.p
+              initial={{ opacity: 0, y: 4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={springTransition}
+              className="text-xs text-muted-foreground/70"
+            >
+              あと{remainingForPhilosophy}回で哲学を生成できます
+            </motion.p>
+          )}
+        </AnimatePresence>
+      </div>
 
       {/* Input */}
-      <form onSubmit={handleSubmit} className="flex items-end gap-2">
-        <div className="flex-1 flex items-end glass-compass rounded-2xl p-2 focus-within:glass-compass-hover transition-colors">
+      <form onSubmit={handleSubmit} className="flex items-end gap-2 min-w-0">
+        <div className="flex-1 min-w-0 flex items-end glass-compass rounded-2xl p-2 focus-within:glass-compass-hover transition-colors">
           <textarea
             ref={inputRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="メッセージを入力..."
+            placeholder={messages.length === 0 ? "気軽に話しかけてみてください..." : "メッセージを入力..."}
             aria-label="AIコーチへのメッセージを入力"
             aria-busy={isChatLoading}
             rows={1}

--- a/src/components/features/compass/PhilosophyChat.tsx
+++ b/src/components/features/compass/PhilosophyChat.tsx
@@ -15,6 +15,7 @@ interface PhilosophyChatProps {
   onResetChat: () => void;
   isChatLoading: boolean;
   isPhilosophyLoading: boolean;
+  currentSuggestions: string[];
 }
 
 // **text** の前後に半角スペースがない場合でも太字になるよう補完する
@@ -22,10 +23,28 @@ function normalizeMarkdown(content: string): string {
   return content.replace(/\*\*(.+?)\*\*/g, (_, inner) => ` **${inner}** `);
 }
 
+const STARTER_CHIPS = [
+  "最近ハマっていることを話したい",
+  "時間を忘れて没頭できることがある",
+  "自分の強みについて考えたい",
+  "人生でやりたいことを整理したい",
+];
+
 const messageVariants = {
   hidden: { opacity: 0, y: 12, scale: 0.96 },
   show: { opacity: 1, y: 0, scale: 1, transition: springTransition },
   exit: { opacity: 0, scale: 0.95, transition: { ...springTransition, duration: 0.15 } },
+};
+
+const chipVariants = {
+  hidden: { opacity: 0, y: 6, scale: 0.95 },
+  show: (i: number) => ({
+    opacity: 1,
+    y: 0,
+    scale: 1,
+    transition: { ...springTransition, delay: i * 0.05 },
+  }),
+  exit: { opacity: 0, scale: 0.92, transition: { duration: 0.1 } },
 };
 
 export function PhilosophyChat({
@@ -35,6 +54,7 @@ export function PhilosophyChat({
   onResetChat,
   isChatLoading,
   isPhilosophyLoading,
+  currentSuggestions,
 }: PhilosophyChatProps) {
   const [input, setInput] = useState("");
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -63,7 +83,22 @@ export function PhilosophyChat({
     }
   };
 
+  const handleChipClick = (text: string) => {
+    if (isChatLoading) return;
+    onSendMessage(text);
+  };
+
   const canGeneratePhilosophy = messages.length >= 4 && !isChatLoading;
+
+  const remainingForPhilosophy = Math.max(0, 4 - messages.length);
+  const showProgressHint = messages.length < 4;
+
+  // Show quick-reply chips only after last AI message, not while loading
+  const lastMessage = messages[messages.length - 1];
+  const showQuickReplies =
+    !isChatLoading &&
+    currentSuggestions.length > 0 &&
+    lastMessage?.role === "assistant";
 
   return (
     <div className="flex flex-col h-full">
@@ -113,57 +148,108 @@ export function PhilosophyChat({
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
-            className="flex flex-col items-center justify-center h-full text-center py-12"
+            className="flex flex-col items-center justify-center h-full text-center py-8"
           >
             <MessageCircle className="w-8 h-8 text-compass/40 mb-4" />
-            <p className="text-muted-foreground text-sm max-w-xs">
-              AIコーチとの対話で、あなたの価値観を発掘しましょう。まずは何か話しかけてみてください。
+            <p className="text-muted-foreground text-sm max-w-xs mb-6">
+              AIコーチとの対話で、あなたの価値観を発掘しましょう。
             </p>
+            {/* Starter chips */}
+            <div className="flex flex-wrap justify-center gap-2 max-w-sm">
+              {STARTER_CHIPS.map((chip, i) => (
+                <motion.button
+                  key={chip}
+                  custom={i}
+                  variants={chipVariants}
+                  initial="hidden"
+                  animate="show"
+                  onClick={() => handleChipClick(chip)}
+                  whileHover={{ y: -2, scale: 1.02 }}
+                  whileTap={{ scale: 0.96 }}
+                  transition={springTransition}
+                  className="px-3 py-2 rounded-xl text-sm bg-compass-subtle text-compass border border-compass-border hover:bg-compass/15 transition-colors"
+                >
+                  {chip}
+                </motion.button>
+              ))}
+            </div>
           </motion.div>
         )}
 
         <AnimatePresence>
-          {messages.map((message) => (
-            <motion.div
-              key={message.id}
-              variants={messageVariants}
-              initial="hidden"
-              animate="show"
-              exit="exit"
-              className={cn(
-                "flex",
-                message.role === "user" ? "justify-end" : "justify-start"
-              )}
-            >
-              <div
-                className={cn(
-                  "max-w-[85%] px-4 py-3 rounded-2xl text-sm leading-relaxed",
-                  message.role === "user"
-                    ? "bubble-user rounded-br-md whitespace-pre-wrap"
-                    : "bubble-assistant rounded-bl-md"
-                )}
-              >
-                {message.role === "user" ? (
-                  message.content
-                ) : (
-                  <ReactMarkdown
-                    components={{
-
-                      p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
-                      strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
-                      em: ({ children }) => <em className="italic">{children}</em>,
-                      ul: ({ children }) => <ul className="list-disc pl-4 mb-2 space-y-1">{children}</ul>,
-                      ol: ({ children }) => <ol className="list-decimal pl-4 mb-2 space-y-1">{children}</ol>,
-                      li: ({ children }) => <li>{children}</li>,
-                      code: ({ children }) => <code className="bg-foreground/10 rounded px-1 py-0.5 text-xs font-mono">{children}</code>,
-                    }}
+          {messages.map((message, index) => {
+            const isLastAssistant =
+              message.role === "assistant" && index === messages.length - 1;
+            return (
+              <div key={message.id}>
+                <motion.div
+                  variants={messageVariants}
+                  initial="hidden"
+                  animate="show"
+                  exit="exit"
+                  className={cn(
+                    "flex",
+                    message.role === "user" ? "justify-end" : "justify-start"
+                  )}
+                >
+                  <div
+                    className={cn(
+                      "max-w-[85%] px-4 py-3 rounded-2xl text-sm leading-relaxed",
+                      message.role === "user"
+                        ? "bubble-user rounded-br-md whitespace-pre-wrap"
+                        : "bubble-assistant rounded-bl-md"
+                    )}
                   >
-                    {normalizeMarkdown(message.content)}
-                  </ReactMarkdown>
+                    {message.role === "user" ? (
+                      message.content
+                    ) : (
+                      <ReactMarkdown
+                        components={{
+                          p: ({ children }) => <p className="mb-2 last:mb-0">{children}</p>,
+                          strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+                          em: ({ children }) => <em className="italic">{children}</em>,
+                          ul: ({ children }) => <ul className="list-disc pl-4 mb-2 space-y-1">{children}</ul>,
+                          ol: ({ children }) => <ol className="list-decimal pl-4 mb-2 space-y-1">{children}</ol>,
+                          li: ({ children }) => <li>{children}</li>,
+                          code: ({ children }) => <code className="bg-foreground/10 rounded px-1 py-0.5 text-xs font-mono">{children}</code>,
+                        }}
+                      >
+                        {normalizeMarkdown(message.content)}
+                      </ReactMarkdown>
+                    )}
+                  </div>
+                </motion.div>
+
+                {/* Quick-reply chips below the last AI message */}
+                {isLastAssistant && showQuickReplies && (
+                  <motion.div
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0 }}
+                    transition={springTransition}
+                    className="flex flex-wrap gap-2 mt-2 ml-1"
+                  >
+                    {currentSuggestions.map((suggestion, i) => (
+                      <motion.button
+                        key={`${suggestion}-${i}`}
+                        custom={i}
+                        variants={chipVariants}
+                        initial="hidden"
+                        animate="show"
+                        onClick={() => handleChipClick(suggestion)}
+                        whileHover={{ y: -1, scale: 1.02 }}
+                        whileTap={{ scale: 0.96 }}
+                        transition={springTransition}
+                        className="px-3 py-1.5 rounded-xl text-xs bg-compass-subtle text-compass border border-compass-border hover:bg-compass/15 transition-colors"
+                      >
+                        {suggestion}
+                      </motion.button>
+                    ))}
+                  </motion.div>
                 )}
               </div>
-            </motion.div>
-          ))}
+            );
+          })}
         </AnimatePresence>
 
         {/* Loading indicator */}
@@ -183,6 +269,21 @@ export function PhilosophyChat({
           </motion.div>
         )}
       </div>
+
+      {/* Progress hint */}
+      <AnimatePresence>
+        {showProgressHint && messages.length > 0 && (
+          <motion.p
+            initial={{ opacity: 0, y: 4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={springTransition}
+            className="text-xs text-muted-foreground/70 text-center mb-2"
+          >
+            あと{remainingForPhilosophy}回で哲学を生成できます
+          </motion.p>
+        )}
+      </AnimatePresence>
 
       {/* Input */}
       <form onSubmit={handleSubmit} className="flex items-end gap-2">

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -144,6 +144,7 @@ export function useCompass() {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const messagesRef = useRef<ChatMessage[]>([]);
   const [isChatLoading, setIsChatLoading] = useState(false);
+  const [currentSuggestions, setCurrentSuggestions] = useState<string[]>([]);
 
   // 新規セッション中に philosophy_id なしで送ったメッセージをバッファ
   const pendingMessagesRef = useRef<ChatMessage[]>([]);
@@ -208,6 +209,7 @@ export function useCompass() {
     messagesRef.current = [];
     pendingMessagesRef.current = [];
     setMessages([]);
+    setCurrentSuggestions([]);
   }, []);
 
   const openPhilosophySession = useCallback(
@@ -216,6 +218,7 @@ export function useCompass() {
       messagesRef.current = [];
       pendingMessagesRef.current = [];
       setMessages([]);
+      setCurrentSuggestions([]);
 
       const { data: msgRows } = await supabase
         .from("compass_messages")
@@ -241,6 +244,7 @@ export function useCompass() {
     messagesRef.current = [];
     pendingMessagesRef.current = [];
     setMessages([]);
+    setCurrentSuggestions([]);
   }, []);
 
   // ─── Chat ─────────────────────────────────────────────────────────────────
@@ -261,6 +265,7 @@ export function useCompass() {
       const updated = [...messagesRef.current, userMessage];
       messagesRef.current = updated;
       setMessages(updated);
+      setCurrentSuggestions([]);
 
       if (editingPhilosophyId === NEW_SESSION) {
         // 新規セッション: philosophy_id が決まるまでバッファに積む
@@ -297,6 +302,7 @@ export function useCompass() {
           const withAssistant = [...messagesRef.current, assistantMessage];
           messagesRef.current = withAssistant;
           setMessages(withAssistant);
+          setCurrentSuggestions(parsed.data.suggestions ?? []);
 
           if (editingPhilosophyId === NEW_SESSION) {
             pendingMessagesRef.current = [...pendingMessagesRef.current, assistantMessage];
@@ -333,6 +339,7 @@ export function useCompass() {
     messagesRef.current = [];
     pendingMessagesRef.current = [];
     setMessages([]);
+    setCurrentSuggestions([]);
 
     if (editingPhilosophyId !== null && editingPhilosophyId !== NEW_SESSION) {
       await supabase
@@ -797,6 +804,7 @@ export function useCompass() {
     sendMessage,
     isChatLoading,
     resetChat,
+    currentSuggestions,
     // Roadmap
     roadmaps,
     generateRoadmap,

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -52,6 +52,7 @@ export const ChatRequestSchema = z.object({
 
 export const ChatResponseSchema = z.object({
   message: z.string(),
+  suggestions: z.array(z.string()).optional(),
 });
 
 // ─── Compass: Philosophy ──────────────────────────────────────────────────────


### PR DESCRIPTION
## 概要
「会話がむずい」というフィードバックを受けた価値観発掘チャット（PhilosophyChat）の「空のキャンバス問題」を解消する3つのUX改善を実装しました。

## 実装内容

### 1. スターター提案チップ（空状態）
メッセージ0件時に4個のClickableなチップを表示。クリックするとそのテキストを即送信し、最初の一言のハードルを大幅に下げます。

### 2. クイックリプライ候補チップ
- `route.ts`のシステムプロンプトに「返答末尾に`SUGGESTIONS_JSON:[...]`を出力」する指示を追加
- APIがGeminiの出力から`suggestions`フィールドを抽出してレスポンスに含める（パースエラー時はfallbackでなし）
- `ChatResponseSchema`に`suggestions?: string[]`を追加（後方互換）
- `useCompass`フックに`currentSuggestions`状態を追加し、送信時にクリア・AI返答時に更新
- AIメッセージの下にチップ形式で2〜3個表示。クリックで即送信

### 3. プログレスヒント
メッセージ数が4未満の時、入力欄上部に「あと〇回で哲学を生成できます」を表示します。

## 関連
Closes #36
実装計画: #37

🤖 Generated with Claude Code Scheduled Task
