### PR TITLE
勝手に哲学とロードマップが削除されないようにする

### DIFF
--- a/src/components/features/compass/PhilosophyList.tsx
+++ b/src/components/features/compass/PhilosophyList.tsx
@@ -115,7 +115,7 @@ export function PhilosophyList({
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${philosophy.title}」をアクティブにする`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-compass hover:bg-compass-subtle/50 transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-compass hover:bg-compass-subtle/50 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
                 >
                   <Star className="w-4 h-4" />
                 </motion.button>
@@ -126,7 +126,7 @@ export function PhilosophyList({
                 whileTap={{ scale: 0.9 }}
                 transition={springTransition}
                 aria-label={`「${philosophy.title}」を削除`}
-                className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+                className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
               >
                 <Trash2 className="w-4 h-4" />
               </motion.button>

--- a/src/components/features/compass/RoadmapList.tsx
+++ b/src/components/features/compass/RoadmapList.tsx
@@ -140,7 +140,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${displayTitle}」のタイトルを編集`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
                 >
                   <Pencil className="w-4 h-4" />
                 </motion.button>
@@ -150,7 +150,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${displayTitle}」を削除`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
                 >
                   <Trash2 className="w-4 h-4" />
                 </motion.button>

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -392,7 +392,7 @@ export function RoadmapTimeline({
                         whileTap={{ scale: 0.9 }}
                         transition={springTransition}
                         aria-label={`「${milestone.title}」を削除`}
-                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover/milestone:opacity-100"
+                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover/milestone:opacity-100 pointer-events-none group-hover/milestone:pointer-events-auto"
                       >
                         <Trash2 className="w-3.5 h-3.5" />
                       </motion.button>


### PR DESCRIPTION
## 概要
モバイル端末でPhilosophyList・RoadmapList・RoadmapTimelineのアイテムをタップした際、非表示状態（opacity-0）のアクションボタンが誤ってクリックされ、データが削除されてしまうバグを修正。

## 実装内容
根本原因はデスクトップ向けの「ホバーで表示されるアクションボタン」が、モバイルでは視覚的には非表示だが pointer-events が有効なまま残っていること。

以下3ファイルのアクションボタンに `pointer-events-none group-hover:pointer-events-auto` を追加：
- `PhilosophyList.tsx` — SetActiveボタン・削除ボタン
- `RoadmapList.tsx` — 編集ボタン・削除ボタン
- `RoadmapTimeline.tsx` — マイルストーン削除ボタン（`group-hover/milestone:pointer-events-auto`）

デスクトップではホバー時に `group-hover:pointer-events-auto` が有効になり、既存のUXはそのまま維持される。

## 関連
Closes #38
実装計画: #40

🤖 Generated with Claude Code Scheduled Task