### PR TITLE
勝手に哲学とロードマップが削除されないようにする

### DIFF
--- a/src/components/features/compass/PhilosophyList.tsx
+++ b/src/components/features/compass/PhilosophyList.tsx
@@ -115,7 +115,7 @@ export function PhilosophyList({
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${philosophy.title}」をアクティブにする`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-compass hover:bg-compass-subtle/50 transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-compass hover:bg-compass-subtle/50 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
                 >
                   <Star className="w-4 h-4" />
                 </motion.button>
@@ -126,7 +126,7 @@ export function PhilosophyList({
                 whileTap={{ scale: 0.9 }}
                 transition={springTransition}
                 aria-label={`「${philosophy.title}」を削除`}
-                className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+                className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
               >
                 <Trash2 className="w-4 h-4" />
               </motion.button>

--- a/src/components/features/compass/PhilosophyList.tsx
+++ b/src/components/features/compass/PhilosophyList.tsx
@@ -115,7 +115,7 @@ export function PhilosophyList({
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${philosophy.title}」をアクティブにする`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-compass hover:bg-compass-subtle/50 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-compass hover:bg-compass-subtle/50 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
                 >
                   <Star className="w-4 h-4" />
                 </motion.button>
@@ -126,7 +126,7 @@ export function PhilosophyList({
                 whileTap={{ scale: 0.9 }}
                 transition={springTransition}
                 aria-label={`「${philosophy.title}」を削除`}
-                className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
+                className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
               >
                 <Trash2 className="w-4 h-4" />
               </motion.button>

--- a/src/components/features/compass/RoadmapList.tsx
+++ b/src/components/features/compass/RoadmapList.tsx
@@ -140,7 +140,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${displayTitle}」のタイトルを編集`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
                 >
                   <Pencil className="w-4 h-4" />
                 </motion.button>
@@ -150,7 +150,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${displayTitle}」を削除`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 pointer-events-none group-hover:opacity-100 group-hover:pointer-events-auto"
                 >
                   <Trash2 className="w-4 h-4" />
                 </motion.button>

--- a/src/components/features/compass/RoadmapList.tsx
+++ b/src/components/features/compass/RoadmapList.tsx
@@ -140,7 +140,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${displayTitle}」のタイトルを編集`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
                 >
                   <Pencil className="w-4 h-4" />
                 </motion.button>
@@ -150,7 +150,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                   whileTap={{ scale: 0.9 }}
                   transition={springTransition}
                   aria-label={`「${displayTitle}」を削除`}
-                  className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100"
+                  className="p-2 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover:opacity-100 pointer-events-none group-hover:pointer-events-auto"
                 >
                   <Trash2 className="w-4 h-4" />
                 </motion.button>

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -392,7 +392,7 @@ export function RoadmapTimeline({
                         whileTap={{ scale: 0.9 }}
                         transition={springTransition}
                         aria-label={`「${milestone.title}」を削除`}
-                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover/milestone:opacity-100"
+                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover/milestone:opacity-100 pointer-events-none group-hover/milestone:pointer-events-auto"
                       >
                         <Trash2 className="w-3.5 h-3.5" />
                       </motion.button>
@@ -428,7 +428,7 @@ export function RoadmapTimeline({
                                 onUpdateMilestone(milestone.id, { keyActions: updated });
                               }}
                               aria-label="このアクションを削除"
-                              className="opacity-0 group-hover/action:opacity-100 text-muted-foreground hover:text-destructive transition-all flex-shrink-0"
+                              className="opacity-0 group-hover/action:opacity-100 text-muted-foreground hover:text-destructive transition-all flex-shrink-0 pointer-events-none group-hover/action:pointer-events-auto"
                             >
                               <X className="w-3 h-3" />
                             </button>

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -392,7 +392,7 @@ export function RoadmapTimeline({
                         whileTap={{ scale: 0.9 }}
                         transition={springTransition}
                         aria-label={`「${milestone.title}」を削除`}
-                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 group-hover/milestone:opacity-100 pointer-events-none group-hover/milestone:pointer-events-auto"
+                        className="p-1.5 rounded-lg text-muted-foreground hover:text-destructive hover:bg-destructive/10 transition-colors opacity-0 pointer-events-none group-hover/milestone:opacity-100 group-hover/milestone:pointer-events-auto"
                       >
                         <Trash2 className="w-3.5 h-3.5" />
                       </motion.button>
@@ -428,7 +428,7 @@ export function RoadmapTimeline({
                                 onUpdateMilestone(milestone.id, { keyActions: updated });
                               }}
                               aria-label="このアクションを削除"
-                              className="opacity-0 group-hover/action:opacity-100 text-muted-foreground hover:text-destructive transition-all flex-shrink-0 pointer-events-none group-hover/action:pointer-events-auto"
+                              className="opacity-0 pointer-events-none group-hover/action:opacity-100 group-hover/action:pointer-events-auto text-muted-foreground hover:text-destructive transition-all flex-shrink-0"
                             >
                               <X className="w-3 h-3" />
                             </button>


### PR DESCRIPTION
## 概要
モバイル端末でPhilosophyList・RoadmapList・RoadmapTimelineのアクションボタン（削除・編集・SetActive）をタップした際に、`opacity-0` で視覚的には非表示であるにもかかわらずタップイベントを受け取って意図せず操作が実行されてしまうバグを修正。

## 実装内容
`opacity-0` は視覚的な非表示だがポインターイベントは無効化しない。各アクションボタンに `pointer-events-none` をデフォルトで付与し、デスクトップのグループホバー時のみ `group-hover:pointer-events-auto`（名前付きグループの場合は `group-hover/<name>:pointer-events-auto`）で操作を有効化する。

変更ファイル:
- `src/components/features/compass/PhilosophyList.tsx` — SetActiveボタン（line 118）と削除ボタン（line 129）
- `src/components/features/compass/RoadmapList.tsx` — 編集ボタン（line 143）と削除ボタン（line 153）
- `src/components/features/compass/RoadmapTimeline.tsx` — マイルストーン削除ボタン（line 395）とKey Action削除ボタン（line 431）

## 関連
Closes #38
実装計画: #44

🤖 Generated with Claude Code Scheduled Task
