### PR TITLE
todoをdoneにできるようなUI/UX, 機能をさらに考える

### DIFF
--- a/src/app/api/breakdown/route.ts
+++ b/src/app/api/breakdown/route.ts
@@ -29,11 +29,19 @@ Respond STRICTLY with a JSON object matching this schema, without markdown forma
     {
       "title": "動詞で始まる20文字以内の行動（日本語）",
       "estimatedTime": "15分",
+      "estimatedMinutes": 15,
       "actionLink": "https://example.com/useful-link"
     }
   ],
-  "firstStep": "今すぐできる最小の着手行動（1文で、動詞で始める）"
+  "firstStep": "今すぐ物理的に始められる最小の着手行動（1文、動詞で始める）"
 }
+
+Instructions for estimatedTime:
+- Provide a human-readable estimate (e.g. "15分", "1時間", "30分").
+
+Instructions for estimatedMinutes:
+- Provide the same estimate as an integer number of minutes (e.g. 15, 60, 30).
+- This is required for every task.
 
 Instructions for actionLink:
 - If a task involves buying something, provide an Amazon or specific store search link.
@@ -41,9 +49,11 @@ Instructions for actionLink:
 - ONLY provide an actionLink if it's genuinely useful for immediate execution. Otherwise, optionally omit it.
 
 Instructions for firstStep:
-- Identify the single smallest action that would get the user started right now.
-- It should take less than 5 minutes and create momentum.
-- Write it as a concrete verb phrase in Japanese (e.g. "レシピ動画を1本だけ開いて見てみる").
+- CRITICAL: The firstStep must be a PHYSICAL ACTION the user can start within 2 minutes right now.
+- It must be the absolute minimum step — not "prepare" or "plan", but a single concrete physical action.
+- BAD examples: "うどん作りの準備をする", "材料を確認する"
+- GOOD examples: "Amazonで『麺棒』と検索して商品ページを開く", "テキストエディタを開いて要件を1行書く", "YouTubeで『手打ちうどん 初心者』と検索する"
+- Write it as a concrete verb phrase in Japanese with a specific tool/site/object named.
 `;
 
 export async function POST(req: Request) {

--- a/src/app/api/nudge/route.ts
+++ b/src/app/api/nudge/route.ts
@@ -1,0 +1,105 @@
+import { GoogleGenerativeAI } from "@google/generative-ai";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getErrorMessage } from "@/lib/utils";
+
+const NudgeRequestTaskSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  estimatedMinutes: z.number().optional(),
+  parentTitle: z.string().optional(),
+  linkedGoal: z.string().optional(),
+});
+
+const NudgeRequestSchema = z.object({
+  tasks: z.array(NudgeRequestTaskSchema).min(1),
+});
+
+const NudgeSuggestionSchema = z.object({
+  taskId: z.string(),
+  reason: z.string().max(40),
+});
+
+const NudgeResponseSchema = z.object({
+  suggestions: z.array(NudgeSuggestionSchema).max(3),
+});
+
+const systemPrompt = `
+You are a smart task prioritization assistant ("Smart Nudge").
+Given a list of incomplete tasks, select the 3 most actionable tasks for the user to focus on right now.
+
+SELECTION CRITERIA (in priority order):
+1. Tasks with estimatedMinutes <= 15 (quick wins) — always prioritize these.
+2. Tasks with a concrete actionLink or specific tool/service mentioned.
+3. Tasks that have momentum (part of an in-progress project).
+4. Tasks linked to long-term goals (linkedGoal present).
+
+For each selected task, write a short Japanese reason (max 40 chars) explaining WHY it was chosen.
+Example reasons: "今すぐ15分で終わる", "目標達成への第一歩", "手が止まっているプロジェクトを再始動"
+
+CRITICAL: Respond only in JSON. No markdown. Select at most 3 tasks. Respond in this exact format:
+{
+  "suggestions": [
+    { "taskId": "<id>", "reason": "<理由（日本語40文字以内）>" },
+    { "taskId": "<id>", "reason": "<理由（日本語40文字以内）>" },
+    { "taskId": "<id>", "reason": "<理由（日本語40文字以内）>" }
+  ]
+}
+`;
+
+export async function POST(req: Request) {
+  try {
+    const body: unknown = await req.json();
+    const parsed = NudgeRequestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+
+    const { tasks } = parsed.data;
+
+    const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: "API key not configured", errorCode: "API_KEY_MISSING" }, { status: 500 });
+    }
+
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({
+      model: "gemini-3-flash-preview",
+      systemInstruction: systemPrompt,
+    });
+
+    const taskList = tasks
+      .map((t) => {
+        const parts = [`id: ${t.id}`, `title: ${t.title}`];
+        if (t.estimatedMinutes !== undefined) parts.push(`estimatedMinutes: ${t.estimatedMinutes}`);
+        if (t.parentTitle) parts.push(`parentProject: ${t.parentTitle}`);
+        if (t.linkedGoal) parts.push(`linkedGoal: ${t.linkedGoal}`);
+        return `{ ${parts.join(", ")} }`;
+      })
+      .join("\n");
+
+    const result = await model.generateContent(`Tasks:\n${taskList}`);
+    const text = result.response.text();
+
+    const jsonMatch = text.match(/```json\n([\s\S]*?)\n```/) ?? text.match(/\{[\s\S]*\}/);
+    const jsonString = jsonMatch ? (jsonMatch[1] ?? jsonMatch[0]) : text;
+
+    try {
+      const nudge = NudgeResponseSchema.parse(JSON.parse(jsonString));
+      return NextResponse.json(nudge);
+    } catch {
+      return NextResponse.json({ error: "Failed to parse AI response", errorCode: "AI_PARSE_FAILURE" }, { status: 502 });
+    }
+  } catch (error: unknown) {
+    if (error instanceof z.ZodError) {
+      return NextResponse.json({ error: "Invalid request", errorCode: "VALIDATION_ERROR" }, { status: 400 });
+    }
+    const msg = error instanceof Error ? error.message.toLowerCase() : "";
+    if (msg.includes("429") || msg.includes("quota") || msg.includes("rate limit")) {
+      return NextResponse.json({ error: "Rate limited", errorCode: "RATE_LIMIT" }, { status: 429 });
+    }
+    console.error("Error in nudge API:", getErrorMessage(error));
+    return NextResponse.json({ error: "Failed to process request", errorCode: "INTERNAL_ERROR" }, { status: 500 });
+  }
+}

--- a/src/app/api/nudge/route.ts
+++ b/src/app/api/nudge/route.ts
@@ -2,6 +2,7 @@ import { GoogleGenerativeAI } from "@google/generative-ai";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { getErrorMessage } from "@/lib/utils";
+import { NudgeResponseSchema } from "@/lib/schemas";
 
 const NudgeRequestTaskSchema = z.object({
   id: z.string(),
@@ -13,15 +14,6 @@ const NudgeRequestTaskSchema = z.object({
 
 const NudgeRequestSchema = z.object({
   tasks: z.array(NudgeRequestTaskSchema).min(1),
-});
-
-const NudgeSuggestionSchema = z.object({
-  taskId: z.string(),
-  reason: z.string().max(40),
-});
-
-const NudgeResponseSchema = z.object({
-  suggestions: z.array(NudgeSuggestionSchema).max(3),
 });
 
 const systemPrompt = `

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -25,6 +25,7 @@ export default function Home() {
     isLoading,
     isBreakingDown,
     completedCount,
+    streakDays,
     scheduleTask,
     unscheduleTask,
   } = useTasks();
@@ -86,6 +87,7 @@ export default function Home() {
               onUnscheduleTask={unscheduleTask}
               newlyBreakdownTaskId={lastBreakdownTaskId}
               onDismissSchedulingPrompt={() => setLastBreakdownTaskId(null)}
+              streakDays={streakDays}
             />
 
             {/* Bulk action bar */}

--- a/src/components/features/task/SmartNudge.tsx
+++ b/src/components/features/task/SmartNudge.tsx
@@ -1,20 +1,14 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Sparkles, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
 import { Task, TaskItem, TaskStatus } from "./TaskItem";
 import { springTransition } from "@/lib/motion";
-import { z } from "zod";
+import { NudgeCacheSchema, NudgeResponseSchema } from "@/lib/schemas";
+import { getTodayStr } from "@/lib/date";
 
-const NudgeSuggestionSchema = z.object({
-  taskId: z.string(),
-  reason: z.string(),
-});
-
-const NudgeResponseSchema = z.object({
-  suggestions: z.array(NudgeSuggestionSchema),
-});
+const CACHE_KEY = "smart_nudge_cache";
 
 interface SmartNudgeSuggestion {
   task: Task;
@@ -33,6 +27,41 @@ interface SmartNudgeProps {
   onUnscheduleTask?: (id: string) => void;
 }
 
+function loadCache(allTasks: Task[]): SmartNudgeSuggestion[] | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = NudgeCacheSchema.safeParse(JSON.parse(raw));
+    if (!parsed.success || parsed.data.date !== getTodayStr()) return null;
+
+    const resolved = parsed.data.suggestions
+      .map((s) => {
+        const task = allTasks.find((t) => t.id === s.taskId);
+        if (!task) return null;
+        return { task, reason: s.reason };
+      })
+      .filter((s): s is SmartNudgeSuggestion => s !== null);
+
+    return resolved.length > 0 ? resolved : null;
+  } catch {
+    return null;
+  }
+}
+
+function saveCache(suggestions: SmartNudgeSuggestion[]) {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        date: getTodayStr(),
+        suggestions: suggestions.map((s) => ({ taskId: s.task.id, reason: s.reason })),
+      })
+    );
+  } catch {
+    // localStorage unavailable — ignore
+  }
+}
+
 export function SmartNudge({
   incompleteTasks,
   allTasks,
@@ -47,7 +76,7 @@ export function SmartNudge({
   const [suggestions, setSuggestions] = useState<SmartNudgeSuggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [showAll, setShowAll] = useState(false);
-  const [taskCountAtLastFetch, setTaskCountAtLastFetch] = useState(0);
+  const initialized = useRef(false);
 
   const fetchNudge = useCallback(async () => {
     if (incompleteTasks.length === 0) return;
@@ -86,7 +115,7 @@ export function SmartNudge({
         .filter((s): s is SmartNudgeSuggestion => s !== null);
 
       setSuggestions(resolved);
-      setTaskCountAtLastFetch(incompleteTasks.length);
+      saveCache(resolved);
     } catch {
       // silently fail — nudge is non-critical
     } finally {
@@ -94,16 +123,22 @@ export function SmartNudge({
     }
   }, [incompleteTasks, allTasks]);
 
-  // Fetch on mount and when task count changes meaningfully (completion events)
+  // マウント時のみ: キャッシュがあれば使い、なければAPIを叩く
   useEffect(() => {
-    const countChanged = Math.abs(incompleteTasks.length - taskCountAtLastFetch) >= 1;
-    if (suggestions.length === 0 || countChanged) {
+    if (initialized.current) return;
+    initialized.current = true;
+
+    const cached = loadCache(allTasks);
+    if (cached) {
+      setSuggestions(cached);
+    } else {
       void fetchNudge();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [incompleteTasks.length]);
+  // allTasksとfetchNudgeはマウント時の値のみ使うため依存に含めない
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // Filter out completed tasks from current suggestions
+  // 完了済みタスクをリアルタイムに除外
   const activeSuggestions = suggestions.filter(
     (s) => s.task.status !== "done" && s.task.status !== "canceled" && incompleteTasks.some((t) => t.id === s.task.id)
   );
@@ -175,7 +210,7 @@ export function SmartNudge({
               onEditBreakdown={onEditBreakdown}
               onScheduleTask={onScheduleTask}
               onUnscheduleTask={onUnscheduleTask}
-              isSubTask
+              isSubTask={!!s.task.parentId}
             />
             <p className="text-xs text-muted-foreground/70 pl-3 pb-0.5">
               {s.reason}

--- a/src/components/features/task/SmartNudge.tsx
+++ b/src/components/features/task/SmartNudge.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Sparkles, ChevronDown, ChevronUp, Loader2 } from "lucide-react";
+import { Task, TaskItem, TaskStatus } from "./TaskItem";
+import { springTransition } from "@/lib/motion";
+import { z } from "zod";
+
+const NudgeSuggestionSchema = z.object({
+  taskId: z.string(),
+  reason: z.string(),
+});
+
+const NudgeResponseSchema = z.object({
+  suggestions: z.array(NudgeSuggestionSchema),
+});
+
+interface SmartNudgeSuggestion {
+  task: Task;
+  reason: string;
+}
+
+interface SmartNudgeProps {
+  incompleteTasks: Task[];
+  allTasks: Task[];
+  onToggleTask: (id: string) => void;
+  onChangeTaskStatus: (id: string, status: TaskStatus) => void;
+  onDeleteTask: (id: string) => void;
+  onEditTask: (id: string, newTitle: string) => void;
+  onEditBreakdown?: (taskId: string, instruction: string) => Promise<void>;
+  onScheduleTask?: (id: string, date: string, time?: string) => void;
+  onUnscheduleTask?: (id: string) => void;
+}
+
+export function SmartNudge({
+  incompleteTasks,
+  allTasks,
+  onToggleTask,
+  onChangeTaskStatus,
+  onDeleteTask,
+  onEditTask,
+  onEditBreakdown,
+  onScheduleTask,
+  onUnscheduleTask,
+}: SmartNudgeProps) {
+  const [suggestions, setSuggestions] = useState<SmartNudgeSuggestion[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  const [taskCountAtLastFetch, setTaskCountAtLastFetch] = useState(0);
+
+  const fetchNudge = useCallback(async () => {
+    if (incompleteTasks.length === 0) return;
+
+    setIsLoading(true);
+    try {
+      const payload = incompleteTasks.slice(0, 30).map((t) => {
+        const parent = t.parentId ? allTasks.find((p) => p.id === t.parentId) : undefined;
+        return {
+          id: t.id,
+          title: t.title,
+          estimatedMinutes: t.estimatedMinutes,
+          parentTitle: parent?.title,
+          linkedGoal: t.linkedGoal,
+        };
+      });
+
+      const res = await fetch("/api/nudge", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tasks: payload }),
+      });
+
+      if (!res.ok) return;
+
+      const data: unknown = await res.json();
+      const parsed = NudgeResponseSchema.safeParse(data);
+      if (!parsed.success) return;
+
+      const resolved = parsed.data.suggestions
+        .map((s) => {
+          const task = allTasks.find((t) => t.id === s.taskId);
+          if (!task) return null;
+          return { task, reason: s.reason };
+        })
+        .filter((s): s is SmartNudgeSuggestion => s !== null);
+
+      setSuggestions(resolved);
+      setTaskCountAtLastFetch(incompleteTasks.length);
+    } catch {
+      // silently fail — nudge is non-critical
+    } finally {
+      setIsLoading(false);
+    }
+  }, [incompleteTasks, allTasks]);
+
+  // Fetch on mount and when task count changes meaningfully (completion events)
+  useEffect(() => {
+    const countChanged = Math.abs(incompleteTasks.length - taskCountAtLastFetch) >= 1;
+    if (suggestions.length === 0 || countChanged) {
+      void fetchNudge();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [incompleteTasks.length]);
+
+  // Filter out completed tasks from current suggestions
+  const activeSuggestions = suggestions.filter(
+    (s) => s.task.status !== "done" && s.task.status !== "canceled" && incompleteTasks.some((t) => t.id === s.task.id)
+  );
+
+  if (incompleteTasks.length === 0) return null;
+
+  const visibleSuggestions = showAll ? activeSuggestions : activeSuggestions.slice(0, 3);
+  const hiddenCount = activeSuggestions.length - 3;
+
+  return (
+    <div className="flex flex-col gap-2 mb-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Sparkles className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="text-xs font-semibold tracking-wide text-muted-foreground uppercase">
+            AIおすすめ
+          </span>
+        </div>
+        <motion.button
+          onClick={() => void fetchNudge()}
+          disabled={isLoading}
+          className="text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-40"
+          whileTap={{ scale: 0.95 }}
+          transition={springTransition}
+          title="おすすめを更新"
+        >
+          {isLoading ? (
+            <Loader2 className="w-3.5 h-3.5 animate-spin" />
+          ) : (
+            "更新"
+          )}
+        </motion.button>
+      </div>
+
+      {/* Loading skeleton */}
+      <AnimatePresence>
+        {isLoading && activeSuggestions.length === 0 && (
+          <motion.div
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            className="flex flex-col gap-1.5"
+          >
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-12 rounded-2xl glass animate-pulse bg-secondary/20" />
+            ))}
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* Suggestions */}
+      <AnimatePresence>
+        {visibleSuggestions.map((s) => (
+          <motion.div
+            key={s.task.id}
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={springTransition}
+            className="flex flex-col gap-1"
+          >
+            <TaskItem
+              task={s.task}
+              onToggle={onToggleTask}
+              onChangeStatus={onChangeTaskStatus}
+              onDelete={onDeleteTask}
+              onEdit={onEditTask}
+              onEditBreakdown={onEditBreakdown}
+              onScheduleTask={onScheduleTask}
+              onUnscheduleTask={onUnscheduleTask}
+              isSubTask
+            />
+            <p className="text-xs text-muted-foreground/70 pl-3 pb-0.5">
+              {s.reason}
+            </p>
+          </motion.div>
+        ))}
+      </AnimatePresence>
+
+      {/* Show more / less */}
+      {activeSuggestions.length > 3 && (
+        <motion.button
+          onClick={() => setShowAll((prev) => !prev)}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors py-1 px-2 rounded-lg hover:bg-secondary/50 self-start"
+          whileTap={{ scale: 0.97 }}
+          transition={springTransition}
+        >
+          {showAll ? (
+            <>
+              <ChevronUp className="w-3 h-3" />
+              折りたたむ
+            </>
+          ) : (
+            <>
+              <ChevronDown className="w-3 h-3" />
+              残り{hiddenCount}件を表示
+            </>
+          )}
+        </motion.button>
+      )}
+    </div>
+  );
+}

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -20,6 +20,7 @@ export interface Task {
   subTasks?: Task[];
   actionLink?: string;
   estimatedTime?: string;
+  estimatedMinutes?: number;
   linkedGoal?: string;
   linkedRoadmapId?: string;
   linkedMilestoneId?: string;
@@ -329,6 +330,11 @@ export function TaskItem({
                       <span>{completedSubtasks}/{totalSubtasks}</span>
                       <span className="hidden sm:inline">サブタスク</span>
                     </div>
+                  )}
+                  {task.estimatedMinutes !== undefined && task.estimatedMinutes <= 15 && (
+                    <span className="flex items-center gap-1 bg-primary/10 border border-primary/20 px-2 py-0.5 rounded-md text-xs font-medium text-primary">
+                      ⚡ 今すぐ
+                    </span>
                   )}
                   {task.estimatedTime && (
                     <span className="flex items-center gap-1 bg-secondary/50 px-2 py-0.5 rounded-md text-xs text-muted-foreground">

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -3,6 +3,8 @@
 import { useState, useCallback, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Task, TaskItem, TaskStatus } from "./TaskItem";
+import { SmartNudge } from "./SmartNudge";
+import { StreakBadge } from "@/components/ui/StreakBadge";
 import { SchedulingPicker } from "./SchedulingPicker";
 import { cn } from "@/lib/utils";
 import { springTransition, STAGGER_FAST } from "@/lib/motion";
@@ -21,6 +23,7 @@ interface TaskListProps {
   /** ID of the task that just had Breakdown run — shows inline SchedulingPicker */
   newlyBreakdownTaskId?: string | null;
   onDismissSchedulingPrompt?: () => void;
+  streakDays?: number;
 }
 
 interface TaskWithIndex extends Task {
@@ -49,6 +52,7 @@ export function TaskList({
   onUnscheduleTask,
   newlyBreakdownTaskId,
   onDismissSchedulingPrompt,
+  streakDays = 0,
 }: TaskListProps) {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
@@ -198,7 +202,7 @@ export function TaskList({
       className="flex flex-col w-full max-w-2xl mx-auto mt-4 px-0 sm:px-2"
     >
       {/* View Toggle */}
-      <div className="flex justify-center mb-3">
+      <div className="flex items-center justify-between mb-3 gap-3">
         <div className="flex p-1 bg-secondary/20 rounded-2xl glass">
           <button
             onClick={() => setViewMode("project")}
@@ -225,6 +229,7 @@ export function TaskList({
             Today
           </button>
         </div>
+        <StreakBadge days={streakDays} />
       </div>
 
       {/* Breakdown直後のインラインスケジューリングプロンプト */}
@@ -257,6 +262,17 @@ export function TaskList({
         </>
       ) : (
         <>
+          <SmartNudge
+            incompleteTasks={processedTasks.filter((t) => t.status !== "done" && t.status !== "canceled")}
+            allTasks={tasks}
+            onToggleTask={onToggleTask}
+            onChangeTaskStatus={onChangeTaskStatus}
+            onDeleteTask={onDeleteTask}
+            onEditTask={onEditTask}
+            onEditBreakdown={onEditBreakdown}
+            onScheduleTask={onScheduleTask}
+            onUnscheduleTask={onUnscheduleTask}
+          />
           {renderGroup(todayBucketTasks, "Today", true, true, "今日の予定はありません")}
           {renderGroup(scheduledBucketTasks, "Scheduled", false, true)}
           {renderGroup(somedayBucketTasks, "Someday", true, true, "いつかやるタスクはありません")}

--- a/src/components/ui/StreakBadge.tsx
+++ b/src/components/ui/StreakBadge.tsx
@@ -23,7 +23,7 @@ export function StreakBadge({ days, className }: StreakBadgeProps) {
       )}
       whileHover={{ y: -1 }}
       transition={springTransition}
-      title={isActive ? `${days}日連続でタスクを完了しています` : "今日タスクを完了してStreakを始めよう"}
+      title={isActive ? `${days}日連続でタスクを完了しています` : "今日タスクを完了して連続記録を始めよう"}
     >
       <span className={cn("text-sm", isActive ? "opacity-100" : "opacity-40")}>🔥</span>
       {isActive ? (
@@ -32,7 +32,7 @@ export function StreakBadge({ days, className }: StreakBadgeProps) {
           <span className="text-muted-foreground ml-0.5">日連続</span>
         </span>
       ) : (
-        <span>Streakを始めよう</span>
+        <span>連続記録を始めよう</span>
       )}
     </motion.div>
   );

--- a/src/components/ui/StreakBadge.tsx
+++ b/src/components/ui/StreakBadge.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { springTransition } from "@/lib/motion";
+import { cn } from "@/lib/utils";
+
+interface StreakBadgeProps {
+  days: number;
+  className?: string;
+}
+
+export function StreakBadge({ days, className }: StreakBadgeProps) {
+  const isActive = days > 0;
+
+  return (
+    <motion.div
+      className={cn(
+        "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium transition-colors",
+        isActive
+          ? "bg-primary/10 border border-primary/20 text-foreground"
+          : "bg-secondary/30 border border-foreground/10 text-muted-foreground",
+        className
+      )}
+      whileHover={{ y: -1 }}
+      transition={springTransition}
+      title={isActive ? `${days}日連続でタスクを完了しています` : "今日タスクを完了してStreakを始めよう"}
+    >
+      <span className={cn("text-sm", isActive ? "opacity-100" : "opacity-40")}>🔥</span>
+      {isActive ? (
+        <span>
+          <span className="font-bold text-sm">{days}</span>
+          <span className="text-muted-foreground ml-0.5">日連続</span>
+        </span>
+      ) : (
+        <span>Streakを始めよう</span>
+      )}
+    </motion.div>
+  );
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -16,6 +16,7 @@ export function useTasks() {
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(true);
+  const [streakDays, setStreakDays] = useState(0);
 
   const supabase = useMemo(() => createClient(), []);
 
@@ -27,6 +28,7 @@ export function useTasks() {
       title: string;
       status: string;
       estimated_time_label: string | null;
+      estimated_minutes: number | null;
       action_link: string | null;
       parent_id: string | null;
       linked_goal: string | null;
@@ -41,6 +43,7 @@ export function useTasks() {
       title: row.title,
       status: row.status as TaskStatus,
       estimatedTime: row.estimated_time_label ?? undefined,
+      estimatedMinutes: row.estimated_minutes ?? undefined,
       actionLink: row.action_link ?? undefined,
       parentId: row.parent_id ?? undefined,
       linkedGoal: row.linked_goal ?? undefined,
@@ -74,6 +77,61 @@ export function useTasks() {
     fetchTasks();
   }, [rowToTask, supabase]);
 
+  // ─── Streak ────────────────────────────────────────────────────────────────
+
+  const fetchStreak = useCallback(async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const { data } = await supabase
+      .from("daily_completion_log")
+      .select("log_date")
+      .eq("user_id", user.id)
+      .order("log_date", { ascending: false })
+      .limit(365);
+
+    if (!data || data.length === 0) {
+      setStreakDays(0);
+      return;
+    }
+
+    const today = getTodayStr();
+    let streak = 0;
+    let cursor = today;
+
+    for (const row of data) {
+      const logDate = typeof row === "object" && row !== null && "log_date" in row && typeof (row as Record<string, unknown>).log_date === "string"
+        ? (row as Record<string, string>).log_date
+        : null;
+      if (logDate === cursor) {
+        streak++;
+        const d = new Date(cursor);
+        d.setDate(d.getDate() - 1);
+        cursor = d.toISOString().split("T")[0] ?? cursor;
+      } else {
+        break;
+      }
+    }
+
+    setStreakDays(streak);
+  }, [supabase]);
+
+  useEffect(() => {
+    void fetchStreak();
+  }, [fetchStreak]);
+
+  const recordCompletionToday = useCallback(async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const today = getTodayStr();
+    await supabase
+      .from("daily_completion_log")
+      .upsert({ user_id: user.id, log_date: today }, { onConflict: "user_id,log_date" });
+
+    void fetchStreak();
+  }, [supabase, fetchStreak]);
+
   // ─── CRUD ───────────────────────────────────────────────────────────────────
 
   const toggleTask = useCallback(
@@ -90,6 +148,10 @@ export function useTasks() {
         .from("tasks")
         .update({ status: newStatus })
         .eq("id", id);
+
+      if (newStatus === "done") {
+        void recordCompletionToday();
+      }
 
       // サブタスクを done にした時、全兄弟が done/canceled なら親も自動完了
       // 注: siblings は setTasks 前の tasks を参照するため、対象タスク自身はまだ "done" でない状態で評価される
@@ -338,6 +400,7 @@ export function useTasks() {
           title: t.title,
           status: "todo" as const,
           estimated_time_label: t.estimatedTime ?? null,
+          estimated_minutes: t.estimatedMinutes ?? null,
           action_link: t.actionLink ?? null,
           parent_id: parentId,
           position: i + 1,
@@ -356,6 +419,7 @@ export function useTasks() {
           title: t.title,
           status: "todo",
           estimatedTime: t.estimated_time_label ?? undefined,
+          estimatedMinutes: t.estimated_minutes ?? undefined,
           actionLink: t.action_link ?? undefined,
           parentId,
         }));
@@ -571,6 +635,7 @@ export function useTasks() {
     isLoading: isLoading || isFetching,
     isBreakingDown: isLoading,
     completedCount,
+    streakDays,
     todayTasks,
     scheduledTasks,
     somedayTasks,

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -95,19 +95,20 @@ export function useTasks() {
       return;
     }
 
+    const LogRowSchema = z.object({ log_date: z.string() });
+
     const today = getTodayStr();
     let streak = 0;
     let cursor = today;
 
     for (const row of data) {
-      const logDate = typeof row === "object" && row !== null && "log_date" in row && typeof (row as Record<string, unknown>).log_date === "string"
-        ? (row as Record<string, string>).log_date
-        : null;
-      if (logDate === cursor) {
+      const parsed = LogRowSchema.safeParse(row);
+      if (!parsed.success) break;
+      if (parsed.data.log_date === cursor) {
         streak++;
-        const d = new Date(cursor);
-        d.setDate(d.getDate() - 1);
-        cursor = d.toISOString().split("T")[0] ?? cursor;
+        const [y, m, d] = cursor.split("-").map(Number);
+        const prev = new Date(Date.UTC(y!, m! - 1, d! - 1));
+        cursor = prev.toISOString().split("T")[0] ?? cursor;
       } else {
         break;
       }
@@ -187,7 +188,7 @@ export function useTasks() {
         }
       }
     },
-    [tasks, supabase]
+    [tasks, supabase, recordCompletionToday]
   );
 
   const changeTaskStatus = useCallback(
@@ -197,8 +198,12 @@ export function useTasks() {
       );
 
       await supabase.from("tasks").update({ status }).eq("id", id);
+
+      if (status === "done") {
+        void recordCompletionToday();
+      }
     },
-    [supabase]
+    [supabase, recordCompletionToday]
   );
 
   const deleteTask = useCallback(

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -31,6 +31,7 @@ export const RawTaskSchema = z.object({
 export const BreakdownTaskSchema = z.object({
   title: z.string().max(20),
   estimatedTime: z.string().optional(),
+  estimatedMinutes: z.number().optional(),
   actionLink: z.string().optional(),
 });
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -103,6 +103,22 @@ export const RoadmapRequestSchema = z.object({
   }).optional(),
 });
 
+// ─── Nudge ────────────────────────────────────────────────────────────────────
+
+export const NudgeSuggestionSchema = z.object({
+  taskId: z.string(),
+  reason: z.string(),
+});
+
+export const NudgeResponseSchema = z.object({
+  suggestions: z.array(NudgeSuggestionSchema),
+});
+
+export const NudgeCacheSchema = z.object({
+  date: z.string(),
+  suggestions: z.array(NudgeSuggestionSchema),
+});
+
 // ─── User ─────────────────────────────────────────────────────────────────────
 
 export const DisplayNameSchema = z.object({

--- a/supabase/migrations/003_add_streak.sql
+++ b/supabase/migrations/003_add_streak.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- 003_add_streak.sql
+-- Script — Streak: Daily Completion Log
+-- ============================================================
+-- Tracks which days a user completed at least one task.
+-- Used to compute the current streak (consecutive days with completions).
+-- ============================================================
+
+create table daily_completion_log (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid references auth.users not null,
+  log_date   date not null,
+  created_at timestamptz default now(),
+  unique (user_id, log_date)
+);
+
+create index idx_daily_completion_log_user_date on daily_completion_log(user_id, log_date desc);
+
+alter table daily_completion_log enable row level security;
+
+create policy "users can manage own completion log"
+  on daily_completion_log for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 概要

行動科学の知見に基づき、タスクをdoneにする割合を向上させる機能群を実装しました（Phase 1〜2）。

## 実装内容

### Phase 1: 着手摩擦の低減（`estimatedMinutes` + Quick Win バッジ）
- `BreakdownTaskSchema` に `estimatedMinutes: z.number().optional()` を追加
- breakdown API の `firstStep` プロンプトを「2分以内に物理的に始められる動作」に厳格化（例：❌「準備をする」→ ✅「Amazonで『麺棒』と検索する」）
- `TaskItem` に `estimatedMinutes <= 15` のサブタスクへの **「⚡ 今すぐ」バッジ** を追加
- `rowToTask` と `breakdownTask` に `estimated_minutes` の読み書きを追加（DBカラムは既存）

### Phase 2: 選択肢の削減（Smart Nudge）
- `/api/nudge` エンドポイントを新規作成（未完了タスクをGemini Flashに送り、3タスク＋選定理由を返却）
- `SmartNudge` コンポーネントを新規作成（Today ビューを開いた瞬間に AI 選定の3タスクと理由が表示）
- 4件目以降は折りたたみ表示、「更新」ボタンで再取得可能
- 完了済みのタスクはリアルタイムにサジェスト一覧から除外される

### Phase 2: Streak（Loss Aversion による継続動機付け）
- `supabase/migrations/003_add_streak.sql`：`daily_completion_log` テーブル追加
- `toggleTask` の done 遷移時に当日の完了ログを記録（`upsert` で冪等）
- `StreakBadge` コンポーネント新規作成（🔥 N日連続 / 「Streakを始めよう」）
- ビュートグル横に常時表示

## 関連
Closes #46
実装計画: #47

🤖 Generated with Claude Code Scheduled Task

---
_Generated by [Claude Code](https://claude.ai/code/session_017h4ag1wZQrZkhGPHtwwrM1)_