### PR TITLE
次のphaseの機能実装

### DIFF
--- a/src/app/compass/page.tsx
+++ b/src/app/compass/page.tsx
@@ -39,6 +39,7 @@ export default function CompassPage() {
     generateRoadmap,
     isRoadmapLoading,
     markMilestoneImported,
+    completeMilestone,
     deleteRoadmap,
     updateRoadmap,
     addMilestone,
@@ -320,6 +321,9 @@ export default function CompassPage() {
                 }
                 onDeleteMilestone={(milestoneId) =>
                   deleteMilestone(selectedRoadmap.id, milestoneId)
+                }
+                onCompleteMilestone={(milestoneId, done) =>
+                  completeMilestone(selectedRoadmap.id, milestoneId, done)
                 }
                 onEditRoadmapWithAI={(roadmapId, instruction) =>
                   editRoadmapWithAI(roadmapId, instruction)

--- a/src/components/features/compass/RoadmapList.tsx
+++ b/src/components/features/compass/RoadmapList.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { MapPin, Trash2, ChevronRight, Pencil, Check } from "lucide-react";
 import { springTransition } from "@/lib/motion";
+import { cn } from "@/lib/utils";
 import type { Roadmap } from "@/hooks/useCompass";
 
 interface RoadmapListProps {
@@ -122,7 +123,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                         {totalCount > 0 && (
                           <>
                             <span className="text-xs text-muted-foreground">·</span>
-                            <span className={completedCount > 0 ? "text-xs text-compass font-medium" : "text-xs text-muted-foreground"}>
+                            <span className={cn("text-xs", completedCount > 0 ? "text-compass font-medium" : "text-muted-foreground")}>
                               {completedCount}/{totalCount} 完了
                             </span>
                           </>

--- a/src/components/features/compass/RoadmapList.tsx
+++ b/src/components/features/compass/RoadmapList.tsx
@@ -58,6 +58,7 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
     >
       {roadmaps.map((roadmap) => {
         const importedCount = roadmap.milestones.filter((m) => m.isImported).length;
+        const completedCount = roadmap.milestones.filter((m) => m.isCompleted).length;
         const totalCount = roadmap.milestones.length;
         const isEditing = editingId === roadmap.id;
         const displayTitle = roadmap.title ?? roadmap.goal;
@@ -112,12 +113,20 @@ export function RoadmapList({ roadmaps, onSelect, onDelete, onUpdateTitle }: Roa
                       aria-label={`「${displayTitle}」のロードマップを開く`}
                     >
                       <p className="font-semibold text-sm truncate">{displayTitle}</p>
-                      <div className="flex items-center gap-2 mt-0.5">
+                      <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                         <span className="text-xs text-muted-foreground">{roadmap.timeframe}</span>
                         <span className="text-xs text-muted-foreground">·</span>
                         <span className="text-xs text-muted-foreground">
                           {formatCreatedAt(roadmap.createdAt)}
                         </span>
+                        {totalCount > 0 && (
+                          <>
+                            <span className="text-xs text-muted-foreground">·</span>
+                            <span className={completedCount > 0 ? "text-xs text-compass font-medium" : "text-xs text-muted-foreground"}>
+                              {completedCount}/{totalCount} 完了
+                            </span>
+                          </>
+                        )}
                         {importedCount > 0 && (
                           <>
                             <span className="text-xs text-muted-foreground">·</span>

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { MapPin, ArrowRight, Check, Pencil, Trash2, Plus, X, Wand2, Send, Loader2 } from "lucide-react";
+import { MapPin, ArrowRight, Check, Pencil, Trash2, Plus, X, Wand2, Send, Loader2, Circle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { springTransition, STAGGER_FAST } from "@/lib/motion";
 import { toast } from "sonner";
@@ -16,6 +16,7 @@ interface RoadmapTimelineProps {
   onAddMilestone: (milestone: Omit<Milestone, "id">) => void;
   onUpdateMilestone: (milestoneId: string, patch: Partial<Pick<Milestone, "period" | "title" | "description" | "keyActions">>) => void;
   onDeleteMilestone: (milestoneId: string) => void;
+  onCompleteMilestone?: (milestoneId: string, done: boolean) => Promise<void>;
   onEditRoadmapWithAI?: (roadmapId: string, instruction: string) => Promise<void>;
 }
 
@@ -187,6 +188,7 @@ export function RoadmapTimeline({
   onAddMilestone,
   onUpdateMilestone,
   onDeleteMilestone,
+  onCompleteMilestone,
   onEditRoadmapWithAI,
 }: RoadmapTimelineProps) {
   const [showAddForm, setShowAddForm] = useState(false);
@@ -312,6 +314,29 @@ export function RoadmapTimeline({
         )}
       </AnimatePresence>
 
+      {/* Progress bar */}
+      {roadmap.milestones.length > 0 && (() => {
+        const completedCount = roadmap.milestones.filter((m) => m.isCompleted).length;
+        const total = roadmap.milestones.length;
+        const pct = Math.round((completedCount / total) * 100);
+        return (
+          <div className="space-y-1.5">
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>進捗</span>
+              <span className="font-medium text-compass">{completedCount}/{total} 完了 {pct}%</span>
+            </div>
+            <div className="h-1.5 rounded-full bg-compass/10 overflow-hidden">
+              <motion.div
+                className="h-full rounded-full bg-compass"
+                initial={{ width: 0 }}
+                animate={{ width: `${pct}%` }}
+                transition={{ type: "spring", stiffness: 260, damping: 20 }}
+              />
+            </div>
+          </div>
+        );
+      })()}
+
       {/* Timeline */}
       <motion.div
         variants={listVariants}
@@ -330,18 +355,27 @@ export function RoadmapTimeline({
               <motion.div
                 key={milestone.id}
                 variants={itemVariants}
-                className="relative flex gap-4 pb-8 last:pb-0 group/milestone"
+                className={cn(
+                  "relative flex gap-4 pb-8 last:pb-0 group/milestone transition-opacity",
+                  milestone.isCompleted && "opacity-60 grayscale-[40%]"
+                )}
               >
                 {/* Timeline dot */}
                 <div
                   className={cn(
                     "relative z-10 flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center border-2 transition-colors",
-                    isLast
-                      ? "bg-compass/20 border-compass text-compass"
-                      : "bg-background border-compass/30 text-compass/60"
+                    milestone.isCompleted
+                      ? "bg-compass border-compass text-compass-foreground"
+                      : isLast
+                        ? "bg-compass/20 border-compass text-compass"
+                        : "bg-background border-compass/30 text-compass/60"
                   )}
                 >
-                  <span className="text-xs font-bold">{index + 1}</span>
+                  {milestone.isCompleted ? (
+                    <Check className="w-4 h-4" />
+                  ) : (
+                    <span className="text-xs font-bold">{index + 1}</span>
+                  )}
                 </div>
 
                 {/* Content */}
@@ -362,6 +396,30 @@ export function RoadmapTimeline({
                     </div>
 
                     <div className="flex items-center gap-1 flex-shrink-0">
+                      {/* Complete toggle button */}
+                      {onCompleteMilestone && (
+                        <motion.button
+                          onClick={() => void onCompleteMilestone(milestone.id, !milestone.isCompleted)}
+                          whileHover={{ scale: 1.05 }}
+                          whileTap={{ scale: 0.95 }}
+                          transition={{ type: "spring", stiffness: 260, damping: 20 }}
+                          aria-label={milestone.isCompleted ? `「${milestone.title}」を未完了に戻す` : `「${milestone.title}」を完了にする`}
+                          aria-pressed={milestone.isCompleted}
+                          className={cn(
+                            "flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors",
+                            milestone.isCompleted
+                              ? "bg-compass/20 text-compass border border-compass/30"
+                              : "bg-secondary/30 text-foreground hover:bg-compass/10 hover:text-compass border border-border/40"
+                          )}
+                        >
+                          {milestone.isCompleted ? (
+                            <><Check className="w-3 h-3" />完了</>
+                          ) : (
+                            <><Circle className="w-3 h-3" />完了にする</>
+                          )}
+                        </motion.button>
+                      )}
+
                       {/* Import to Engine button */}
                       <motion.button
                         onClick={() => onImportMilestone(milestone)}

--- a/src/components/features/compass/RoadmapTimeline.tsx
+++ b/src/components/features/compass/RoadmapTimeline.tsx
@@ -196,6 +196,10 @@ export function RoadmapTimeline({
   const [aiInstruction, setAiInstruction] = useState("");
   const [isAIEditing, setIsAIEditing] = useState(false);
 
+  const completedCount = roadmap.milestones.filter((m) => m.isCompleted).length;
+  const totalMilestoneCount = roadmap.milestones.length;
+  const completionPct = totalMilestoneCount > 0 ? Math.round((completedCount / totalMilestoneCount) * 100) : 0;
+
   const handleAIEditSubmit = async () => {
     if (!aiInstruction.trim() || !onEditRoadmapWithAI || isAIEditing) return;
     setIsAIEditing(true);
@@ -315,27 +319,22 @@ export function RoadmapTimeline({
       </AnimatePresence>
 
       {/* Progress bar */}
-      {roadmap.milestones.length > 0 && (() => {
-        const completedCount = roadmap.milestones.filter((m) => m.isCompleted).length;
-        const total = roadmap.milestones.length;
-        const pct = Math.round((completedCount / total) * 100);
-        return (
-          <div className="space-y-1.5">
-            <div className="flex items-center justify-between text-xs text-muted-foreground">
-              <span>進捗</span>
-              <span className="font-medium text-compass">{completedCount}/{total} 完了 {pct}%</span>
-            </div>
-            <div className="h-1.5 rounded-full bg-compass/10 overflow-hidden">
-              <motion.div
-                className="h-full rounded-full bg-compass"
-                initial={{ width: 0 }}
-                animate={{ width: `${pct}%` }}
-                transition={{ type: "spring", stiffness: 260, damping: 20 }}
-              />
-            </div>
+      {totalMilestoneCount > 0 && (
+        <div className="space-y-1.5">
+          <div className="flex items-center justify-between text-xs text-muted-foreground">
+            <span>進捗</span>
+            <span className="font-medium text-compass">{completedCount}/{totalMilestoneCount} 完了 {completionPct}%</span>
           </div>
-        );
-      })()}
+          <div className="h-1.5 rounded-full bg-compass/10 overflow-hidden">
+            <motion.div
+              className="h-full rounded-full bg-compass"
+              initial={{ width: 0 }}
+              animate={{ width: `${completionPct}%` }}
+              transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            />
+          </div>
+        </div>
+      )}
 
       {/* Timeline */}
       <motion.div

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -45,6 +45,8 @@ export interface Milestone {
   description: string;
   keyActions: string[];
   isImported?: boolean;
+  isCompleted?: boolean;
+  completedAt?: string;
 }
 
 export interface Roadmap {
@@ -69,6 +71,8 @@ function rowToMilestone(row: {
   description: string;
   key_actions: string[];
   is_imported: boolean;
+  is_completed?: boolean;
+  completed_at?: string | null;
   position: number;
 }): Milestone {
   return {
@@ -78,6 +82,8 @@ function rowToMilestone(row: {
     description: row.description,
     keyActions: row.key_actions,
     isImported: row.is_imported,
+    isCompleted: row.is_completed ?? false,
+    completedAt: row.completed_at ?? undefined,
   };
 }
 
@@ -723,6 +729,39 @@ export function useCompass() {
     [supabase]
   );
 
+  const completeMilestone = useCallback(
+    async (roadmapId: string, milestoneId: string, done: boolean) => {
+      const prevRoadmaps = roadmaps;
+      const now = done ? new Date().toISOString() : undefined;
+
+      setRoadmaps((prev) =>
+        prev.map((r) =>
+          r.id === roadmapId
+            ? {
+                ...r,
+                milestones: r.milestones.map((m) =>
+                  m.id === milestoneId
+                    ? { ...m, isCompleted: done, completedAt: now }
+                    : m
+                ),
+              }
+            : r
+        )
+      );
+
+      const { error } = await supabase
+        .from("milestones")
+        .update({ is_completed: done, completed_at: done ? now : null })
+        .eq("id", milestoneId);
+
+      if (error) {
+        setRoadmaps(prevRoadmaps);
+        toast.error("マイルストーンの更新に失敗しました");
+      }
+    },
+    [roadmaps, supabase]
+  );
+
   const editRoadmapWithAI = useCallback(
     async (roadmapId: string, instruction: string) => {
       // setRoadmaps のコールバック内で最新の roadmaps を参照することで
@@ -810,6 +849,7 @@ export function useCompass() {
     generateRoadmap,
     isRoadmapLoading,
     markMilestoneImported,
+    completeMilestone,
     deleteRoadmap,
     updateRoadmap,
     addMilestone,

--- a/src/hooks/useCompass.ts
+++ b/src/hooks/useCompass.ts
@@ -731,11 +731,12 @@ export function useCompass() {
 
   const completeMilestone = useCallback(
     async (roadmapId: string, milestoneId: string, done: boolean) => {
-      const prevRoadmaps = roadmaps;
       const now = done ? new Date().toISOString() : undefined;
+      let snapshot: Roadmap[] | null = null;
 
-      setRoadmaps((prev) =>
-        prev.map((r) =>
+      setRoadmaps((prev) => {
+        snapshot = prev;
+        return prev.map((r) =>
           r.id === roadmapId
             ? {
                 ...r,
@@ -746,8 +747,8 @@ export function useCompass() {
                 ),
               }
             : r
-        )
-      );
+        );
+      });
 
       const { error } = await supabase
         .from("milestones")
@@ -755,11 +756,11 @@ export function useCompass() {
         .eq("id", milestoneId);
 
       if (error) {
-        setRoadmaps(prevRoadmaps);
+        if (snapshot) setRoadmaps(snapshot);
         toast.error("マイルストーンの更新に失敗しました");
       }
     },
-    [roadmaps, supabase]
+    [supabase]
   );
 
   const editRoadmapWithAI = useCallback(

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -124,6 +124,29 @@ export function useTasks() {
           }
         }
       }
+
+      // linked_milestone_id があるタスクが done になった時、同じマイルストーンに紐づく全タスクが完了なら Toast 通知
+      if (newStatus === "done" && task.linkedMilestoneId) {
+        const linkedTasks = tasks.filter(
+          (t) => t.linkedMilestoneId === task.linkedMilestoneId && t.id !== id
+        );
+        const allLinkedDone = linkedTasks.every(
+          (t) => t.status === "done" || t.status === "canceled"
+        );
+        if (allLinkedDone) {
+          toast.success(
+            `マイルストーン「${task.linkedGoal?.split(" › ")[1] ?? ""}」のタスクが全て完了！`,
+            {
+              description: "Compassでマイルストーンを完了にしましょう",
+              action: {
+                label: "Compassを開く",
+                onClick: () => { window.location.href = "/compass"; },
+              },
+              duration: 8000,
+            }
+          );
+        }
+      }
     },
     [tasks, supabase]
   );

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
@@ -13,6 +14,7 @@ import { ApiError, getUserFriendlyErrorMessage, NETWORK_ERROR_MESSAGE, parseApiE
 const SingleEditResponseSchema = z.object({ task: BreakdownTaskSchema });
 
 export function useTasks() {
+  const router = useRouter();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(true);
@@ -134,13 +136,15 @@ export function useTasks() {
           (t) => t.status === "done" || t.status === "canceled"
         );
         if (allLinkedDone) {
+          const parts = task.linkedGoal?.split(" › ");
+          const milestoneName = parts && parts.length >= 2 ? parts.slice(1).join(" › ") : (task.linkedGoal ?? "");
           toast.success(
-            `マイルストーン「${task.linkedGoal?.split(" › ")[1] ?? ""}」のタスクが全て完了！`,
+            `マイルストーン「${milestoneName}」のタスクが全て完了！`,
             {
               description: "Compassでマイルストーンを完了にしましょう",
               action: {
                 label: "Compassを開く",
-                onClick: () => { window.location.href = "/compass"; },
+                onClick: () => { router.push("/compass"); },
               },
               duration: 8000,
             }


### PR DESCRIPTION
## 概要

マイルストーン完了トラッキング機能を実装し、Compass → Engine → Compass のフィードバックループを完成させました。DBには既存の `is_completed` / `completed_at` カラムを活用しています。

## 実装内容

### useCompass.ts
- `Milestone` 型に `isCompleted?: boolean` / `completedAt?: string` を追加
- `rowToMilestone` で `is_completed` / `completed_at` を読み込むよう拡張
- `completeMilestone(roadmapId, milestoneId, done: boolean)` を新規追加（楽観的更新 + ロールバック対応）

### RoadmapTimeline.tsx
- 各マイルストーンカードに完了トグルボタンを追加（完了済みは `✓ 完了`、未完了は `○ 完了にする`）
- 完了済みマイルストーンは `opacity-60 grayscale-[40%]` + タイムラインドットが緑のチェックアイコンに変化
- タイムライン上部に進捗率バーを追加（`N/M 完了 XX%` + springアニメーション）

### RoadmapList.tsx
- 各ロードマップカードに `N/M 完了` バッジを表示（完了数が1以上の場合は compass カラーで強調）

### useTasks.ts
- `toggleTask` 内で `linked_milestone_id` を持つタスクが `done` になった時、同じマイルストーンの全リンクタスクが完了していればToast通知を表示
- Toast には「Compassを開く」アクションボタンを設置し、Compass画面への導線を提供

## 関連
Closes #49
実装計画: #50

🤖 Generated with Claude Code Scheduled Task