### PR TITLE
タスク削除を慎重にする

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,21 @@ export default function RootLayout({
         <main className="max-w-3xl mx-auto px-4 sm:px-8 pt-14 pb-8 min-h-screen">
           {children}
         </main>
-        <Toaster position="bottom-center" richColors />
+        <Toaster
+          position="bottom-center"
+          toastOptions={{
+            style: {
+              background: "var(--color-popover)",
+              color: "var(--color-foreground)",
+              border: "1px solid var(--color-border)",
+              fontFamily: "var(--font-body)",
+            },
+            actionButtonStyle: {
+              background: "var(--color-foreground)",
+              color: "var(--color-primary-foreground)",
+            },
+          }}
+        />
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { TaskInput } from "@/components/features/task/TaskInput";
 import { TaskList } from "@/components/features/task/TaskList";
 import { useTasks } from "@/hooks/useTasks";
 import { motion, AnimatePresence } from "framer-motion";
 import { Trash2, Sparkles } from "lucide-react";
+import { toast } from "sonner";
 
 const springTransition = { type: "spring" as const, stiffness: 260, damping: 20 };
 
@@ -19,6 +20,7 @@ export default function Home() {
     toggleTask,
     changeTaskStatus,
     deleteTask,
+    undoDelete,
     editTask,
     reorderTasks,
     clearCompleted,
@@ -36,6 +38,14 @@ export default function Home() {
       setLastBreakdownTaskId(newParentId);
     }
   };
+
+  const handleDeleteTask = useCallback((id: string) => {
+    deleteTask(id);
+    toast("タスクを削除しました", {
+      action: { label: "元に戻す", onClick: () => undoDelete(id) },
+      duration: 5000,
+    });
+  }, [deleteTask, undoDelete]);
 
   return (
     <div className="flex flex-col items-center w-full max-w-3xl mx-auto space-y-4 pt-2 sm:pt-4">
@@ -79,7 +89,7 @@ export default function Home() {
               tasks={tasks}
               onToggleTask={toggleTask}
               onChangeTaskStatus={changeTaskStatus}
-              onDeleteTask={deleteTask}
+              onDeleteTask={handleDeleteTask}
               onEditTask={editTask}
               onReorderTasks={reorderTasks}
               onEditBreakdown={editBreakdown}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
@@ -19,6 +19,12 @@ export function useTasks() {
   const [streakDays, setStreakDays] = useState(0);
 
   const supabase = useMemo(() => createClient(), []);
+
+  const pendingDeletesRef = useRef<Map<string, {
+    tasksToRestore: Task[];
+    insertIndex: number;
+    timeoutId: ReturnType<typeof setTimeout>;
+  }>>(new Map());
 
   // ─── DB rows → Task ────────────────────────────────────────────────────────
 
@@ -207,12 +213,38 @@ export function useTasks() {
   );
 
   const deleteTask = useCallback(
-    async (id: string) => {
-      setTasks((prev) => prev.filter((t) => t.id !== id));
-      await supabase.from("tasks").delete().eq("id", id);
+    (id: string) => {
+      setTasks((prev) => {
+        const insertIndex = prev.findIndex((t) => t.id === id);
+        const tasksToRestore = prev.filter((t) => t.id === id || t.parentId === id);
+
+        const timeoutId = setTimeout(async () => {
+          pendingDeletesRef.current.delete(id);
+          const idsToDelete = tasksToRestore.map((t) => t.id);
+          await supabase.from("tasks").delete().in("id", idsToDelete);
+        }, 5000);
+
+        pendingDeletesRef.current.set(id, { tasksToRestore, insertIndex, timeoutId });
+
+        return prev.filter((t) => t.id !== id && t.parentId !== id);
+      });
     },
     [supabase]
   );
+
+  const undoDelete = useCallback((id: string) => {
+    const pending = pendingDeletesRef.current.get(id);
+    if (!pending) return;
+
+    clearTimeout(pending.timeoutId);
+    pendingDeletesRef.current.delete(id);
+
+    setTasks((prev) => {
+      const result = [...prev];
+      result.splice(pending.insertIndex, 0, ...pending.tasksToRestore);
+      return result;
+    });
+  }, []);
 
   const editTask = useCallback(
     async (id: string, newTitle: string) => {
@@ -649,6 +681,7 @@ export function useTasks() {
     toggleTask,
     changeTaskStatus,
     deleteTask,
+    undoDelete,
     editTask,
     reorderTasks,
     clearCompleted,

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -127,6 +127,13 @@ export function useTasks() {
     void fetchStreak();
   }, [fetchStreak]);
 
+  useEffect(() => {
+    const ref = pendingDeletesRef.current;
+    return () => {
+      ref.forEach(({ timeoutId }) => clearTimeout(timeoutId));
+    };
+  }, []);
+
   const recordCompletionToday = useCallback(async () => {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return;
@@ -214,20 +221,30 @@ export function useTasks() {
 
   const deleteTask = useCallback(
     (id: string) => {
+      let tasksToRestore: Task[] = [];
+      let insertIndex = 0;
+
       setTasks((prev) => {
-        const insertIndex = prev.findIndex((t) => t.id === id);
-        const tasksToRestore = prev.filter((t) => t.id === id || t.parentId === id);
-
-        const timeoutId = setTimeout(async () => {
-          pendingDeletesRef.current.delete(id);
-          const idsToDelete = tasksToRestore.map((t) => t.id);
-          await supabase.from("tasks").delete().in("id", idsToDelete);
-        }, 5000);
-
-        pendingDeletesRef.current.set(id, { tasksToRestore, insertIndex, timeoutId });
-
+        insertIndex = prev.findIndex((t) => t.id === id);
+        tasksToRestore = prev.filter((t) => t.id === id || t.parentId === id);
         return prev.filter((t) => t.id !== id && t.parentId !== id);
       });
+
+      const timeoutId = setTimeout(async () => {
+        pendingDeletesRef.current.delete(id);
+        const idsToDelete = tasksToRestore.map((t) => t.id);
+        const { error } = await supabase.from("tasks").delete().in("id", idsToDelete);
+        if (error) {
+          toast.error("削除に失敗しました。もう一度お試しください。");
+          setTasks((prev) => {
+            const result = [...prev];
+            result.splice(insertIndex, 0, ...tasksToRestore);
+            return result;
+          });
+        }
+      }, 5000);
+
+      pendingDeletesRef.current.set(id, { tasksToRestore, insertIndex, timeoutId });
     },
     [supabase]
   );


### PR DESCRIPTION
## 概要
タスク削除ボタンを押した際に即座にDBから削除される挙動を、5秒間の「ソフト削除」に変更。Sonner Toastの「元に戻す」ボタンで5秒以内にキャンセル可能になった。

## 実装内容
- `src/hooks/useTasks.ts`: `deleteTask` をソフト削除に変更し、`undoDelete` を追加
  - `pendingDeletesRef` でタイムアウト・復元データを管理
  - 削除時はUIから即座に消えるが、DB削除は5秒後に遅延実行
  - 親タスク削除時にサブタスク（`parentId === id`）も一緒にUIから除去（バグ修正）
  - `undoDelete(id)` で `clearTimeout` + 元の位置にタスクを復元
- `src/app/page.tsx`: `handleDeleteTask` ラッパーを追加し、削除時に Sonner Toast を表示

## 関連
Closes #51
実装計画: #54

🤖 Generated with Claude Code Scheduled Task
