### PR TITLE
Streak機能強化：at-risk警告・マイルストーン祝福・Streak Freeze

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { TaskInput } from "@/components/features/task/TaskInput";
 import { TaskList } from "@/components/features/task/TaskList";
+import { StreakMilestoneOverlay } from "@/components/ui/StreakMilestoneOverlay";
 import { useTasks } from "@/hooks/useTasks";
 import { motion, AnimatePresence } from "framer-motion";
 import { Trash2, Sparkles } from "lucide-react";
@@ -28,6 +29,11 @@ export default function Home() {
     isBreakingDown,
     completedCount,
     streakDays,
+    streakIsAtRisk,
+    streakMilestone,
+    clearStreakMilestone,
+    availableFreezes,
+    applyStreakFreeze,
     scheduleTask,
     unscheduleTask,
   } = useTasks();
@@ -98,6 +104,14 @@ export default function Home() {
               newlyBreakdownTaskId={lastBreakdownTaskId}
               onDismissSchedulingPrompt={() => setLastBreakdownTaskId(null)}
               streakDays={streakDays}
+              streakIsAtRisk={streakIsAtRisk}
+              availableFreezes={availableFreezes}
+              onStreakFreeze={applyStreakFreeze}
+            />
+
+            <StreakMilestoneOverlay
+              milestone={streakMilestone}
+              onDismiss={clearStreakMilestone}
             />
 
             {/* Bulk action bar */}

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -24,6 +24,9 @@ interface TaskListProps {
   newlyBreakdownTaskId?: string | null;
   onDismissSchedulingPrompt?: () => void;
   streakDays?: number;
+  streakIsAtRisk?: boolean;
+  availableFreezes?: number;
+  onStreakFreeze?: () => void;
 }
 
 interface TaskWithIndex extends Task {
@@ -53,6 +56,9 @@ export function TaskList({
   newlyBreakdownTaskId,
   onDismissSchedulingPrompt,
   streakDays = 0,
+  streakIsAtRisk = false,
+  availableFreezes = 0,
+  onStreakFreeze,
 }: TaskListProps) {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
@@ -229,7 +235,12 @@ export function TaskList({
             Today
           </button>
         </div>
-        <StreakBadge days={streakDays} />
+        <StreakBadge
+          days={streakDays}
+          isAtRisk={streakIsAtRisk}
+          availableFreezes={availableFreezes}
+          onFreeze={onStreakFreeze}
+        />
       </div>
 
       {/* Breakdown直後のインラインスケジューリングプロンプト */}

--- a/src/components/ui/StreakBadge.tsx
+++ b/src/components/ui/StreakBadge.tsx
@@ -7,33 +7,73 @@ import { cn } from "@/lib/utils";
 interface StreakBadgeProps {
   days: number;
   className?: string;
+  isAtRisk?: boolean;
+  availableFreezes?: number;
+  onFreeze?: () => void;
 }
 
-export function StreakBadge({ days, className }: StreakBadgeProps) {
+export function StreakBadge({
+  days,
+  className,
+  isAtRisk = false,
+  availableFreezes = 0,
+  onFreeze,
+}: StreakBadgeProps) {
   const isActive = days > 0;
 
   return (
-    <motion.div
-      className={cn(
-        "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium transition-colors",
-        isActive
-          ? "bg-primary/10 border border-primary/20 text-foreground"
-          : "bg-secondary/30 border border-foreground/10 text-muted-foreground",
-        className
-      )}
-      whileHover={{ y: -1 }}
-      transition={springTransition}
-      title={isActive ? `${days}日連続でタスクを完了しています` : "今日タスクを完了して連続記録を始めよう"}
-    >
-      <span className={cn("text-sm", isActive ? "opacity-100" : "opacity-40")}>🔥</span>
-      {isActive ? (
-        <span>
-          <span className="font-bold text-sm">{days}</span>
-          <span className="text-muted-foreground ml-0.5">日連続</span>
+    <div className="flex items-center gap-2">
+      <motion.div
+        className={cn(
+          "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium transition-colors",
+          isActive && isAtRisk
+            ? "bg-amber-100/60 border border-amber-300/40 text-foreground"
+            : isActive
+              ? "bg-primary/10 border border-primary/20 text-foreground"
+              : "bg-secondary/30 border border-foreground/10 text-muted-foreground",
+          className
+        )}
+        whileHover={{ y: -1 }}
+        transition={springTransition}
+        title={
+          isActive && isAtRisk
+            ? "今日タスクを完了してStreakを守ろう！"
+            : isActive
+              ? `${days}日連続でタスクを完了しています`
+              : "今日タスクを完了して連続記録を始めよう"
+        }
+      >
+        <span
+          className={cn(
+            "text-sm",
+            isActive ? "opacity-100" : "opacity-40",
+            isActive && isAtRisk && "animate-pulse"
+          )}
+        >
+          🔥
         </span>
-      ) : (
-        <span>連続記録を始めよう</span>
+        {isActive ? (
+          <span>
+            <span className="font-bold text-sm">{days}</span>
+            <span className="text-muted-foreground ml-0.5">日連続</span>
+          </span>
+        ) : (
+          <span>連続記録を始めよう</span>
+        )}
+      </motion.div>
+
+      {isActive && isAtRisk && availableFreezes > 0 && onFreeze && (
+        <motion.button
+          onClick={onFreeze}
+          className="flex items-center gap-1 px-2.5 py-1.5 rounded-xl text-xs font-medium bg-blue-100/60 border border-blue-300/40 text-blue-700 hover:bg-blue-200/60 transition-colors"
+          whileHover={{ y: -1 }}
+          whileTap={{ scale: 0.95 }}
+          transition={springTransition}
+          title={`Streak Freeze を使用 (残り${availableFreezes}回)`}
+        >
+          🧊 Freeze
+        </motion.button>
       )}
-    </motion.div>
+    </div>
   );
 }

--- a/src/components/ui/StreakMilestoneOverlay.tsx
+++ b/src/components/ui/StreakMilestoneOverlay.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+interface StreakMilestoneOverlayProps {
+  milestone: number | null;
+  onDismiss: () => void;
+}
+
+export function StreakMilestoneOverlay({ milestone, onDismiss }: StreakMilestoneOverlayProps) {
+  useEffect(() => {
+    if (!milestone) return;
+    const timer = setTimeout(onDismiss, 3000);
+    return () => clearTimeout(timer);
+  }, [milestone, onDismiss]);
+
+  return (
+    <AnimatePresence>
+      {milestone && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/90 backdrop-blur-sm"
+          onClick={onDismiss}
+        >
+          <motion.div
+            initial={{ scale: 0.5, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.8, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 260, damping: 20 }}
+            className="flex flex-col items-center gap-4 p-8 rounded-3xl bg-foreground/5 border border-foreground/10"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <motion.span
+              initial={{ scale: 0 }}
+              animate={{ scale: [0, 1.2, 1] }}
+              transition={{ type: "spring", stiffness: 260, damping: 20, delay: 0.1 }}
+              className="text-6xl"
+            >
+              🔥
+            </motion.span>
+            <div className="text-center">
+              <p className="font-display text-3xl font-bold text-foreground">
+                {milestone}日連続達成！
+              </p>
+              <p className="text-sm text-muted-foreground mt-2">
+                素晴らしい習慣が身についています
+              </p>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
-import { getTodayStr } from "@/lib/date";
+import { getTodayStr, getYesterdayStr } from "@/lib/date";
 import { createClient } from "@/lib/supabase/client";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -19,6 +19,9 @@ export function useTasks() {
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(true);
   const [streakDays, setStreakDays] = useState(0);
+  const [streakIsAtRisk, setStreakIsAtRisk] = useState(false);
+  const [streakMilestone, setStreakMilestone] = useState<number | null>(null);
+  const [availableFreezes, setAvailableFreezes] = useState(0);
 
   const supabase = useMemo(() => createClient(), []);
 
@@ -87,42 +90,80 @@ export function useTasks() {
 
   // ─── Streak ────────────────────────────────────────────────────────────────
 
-  const fetchStreak = useCallback(async () => {
+  const fetchStreak = useCallback(async (): Promise<number> => {
     const { data: { user } } = await supabase.auth.getUser();
-    if (!user) return;
-
-    const { data } = await supabase
-      .from("daily_completion_log")
-      .select("log_date")
-      .eq("user_id", user.id)
-      .order("log_date", { ascending: false })
-      .limit(365);
-
-    if (!data || data.length === 0) {
-      setStreakDays(0);
-      return;
-    }
-
-    const LogRowSchema = z.object({ log_date: z.string() });
+    if (!user) return 0;
 
     const today = getTodayStr();
-    let streak = 0;
-    let cursor = today;
+    const yesterday = getYesterdayStr();
+    const currentMonth = today.slice(0, 7);
 
-    for (const row of data) {
+    const LogRowSchema = z.object({ log_date: z.string() });
+    const FreezeRowSchema = z.object({ freeze_date: z.string() });
+
+    const [logResult, freezeResult] = await Promise.all([
+      supabase
+        .from("daily_completion_log")
+        .select("log_date")
+        .eq("user_id", user.id)
+        .order("log_date", { ascending: false })
+        .limit(365),
+      supabase
+        .from("streak_freezes")
+        .select("freeze_date")
+        .eq("user_id", user.id)
+        .order("freeze_date", { ascending: false })
+        .limit(365),
+    ]);
+
+    const completionDates = new Set<string>();
+    for (const row of (logResult.data ?? [])) {
       const parsed = LogRowSchema.safeParse(row);
-      if (!parsed.success) break;
-      if (parsed.data.log_date === cursor) {
-        streak++;
-        const [y, m, d] = cursor.split("-").map(Number);
-        const prev = new Date(Date.UTC(y!, m! - 1, d! - 1));
-        cursor = prev.toISOString().split("T")[0] ?? cursor;
-      } else {
-        break;
-      }
+      if (parsed.success) completionDates.add(parsed.data.log_date);
+    }
+
+    const freezeDates = new Set<string>();
+    for (const row of (freezeResult.data ?? [])) {
+      const parsed = FreezeRowSchema.safeParse(row);
+      if (parsed.success) freezeDates.add(parsed.data.freeze_date);
+    }
+
+    const freezesThisMonth = [...freezeDates].filter((d) => d.startsWith(currentMonth)).length;
+    setAvailableFreezes(Math.max(0, 3 - freezesThisMonth));
+
+    const effectiveDates = new Set([...completionDates, ...freezeDates]);
+
+    if (effectiveDates.size === 0) {
+      setStreakDays(0);
+      setStreakIsAtRisk(false);
+      return 0;
+    }
+
+    const mostRecent = [...effectiveDates].sort().at(-1)!;
+
+    let cursor: string;
+    if (mostRecent === today) {
+      setStreakIsAtRisk(false);
+      cursor = today;
+    } else if (mostRecent === yesterday) {
+      setStreakIsAtRisk(true);
+      cursor = yesterday;
+    } else {
+      setStreakDays(0);
+      setStreakIsAtRisk(false);
+      return 0;
+    }
+
+    let streak = 0;
+    while (effectiveDates.has(cursor)) {
+      streak++;
+      const [y, m, d] = cursor.split("-").map(Number);
+      const prev = new Date(Date.UTC(y!, m! - 1, d! - 1));
+      cursor = prev.toISOString().split("T")[0] ?? cursor;
     }
 
     setStreakDays(streak);
+    return streak;
   }, [supabase]);
 
   useEffect(() => {
@@ -145,8 +186,25 @@ export function useTasks() {
       .from("daily_completion_log")
       .upsert({ user_id: user.id, log_date: today }, { onConflict: "user_id,log_date" });
 
-    void fetchStreak();
+    const newStreak = await fetchStreak();
+    if (newStreak === 7 || newStreak === 30) {
+      setStreakMilestone(newStreak);
+    }
   }, [supabase, fetchStreak]);
+
+  const applyStreakFreeze = useCallback(async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+    const today = getTodayStr();
+    await supabase
+      .from("streak_freezes")
+      .upsert({ user_id: user.id, freeze_date: today }, { onConflict: "user_id,freeze_date" });
+    await fetchStreak();
+  }, [supabase, fetchStreak]);
+
+  const clearStreakMilestone = useCallback(() => {
+    setStreakMilestone(null);
+  }, []);
 
   // ─── CRUD ───────────────────────────────────────────────────────────────────
 
@@ -717,6 +775,11 @@ export function useTasks() {
     isBreakingDown: isLoading,
     completedCount,
     streakDays,
+    streakIsAtRisk,
+    streakMilestone,
+    clearStreakMilestone,
+    availableFreezes,
+    applyStreakFreeze,
     todayTasks,
     scheduledTasks,
     somedayTasks,

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -6,6 +6,12 @@ export function getTodayStr(): string {
   return toDateStr(new Date());
 }
 
+export function getYesterdayStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return toDateStr(d);
+}
+
 export function getTomorrowStr(): string {
   const d = new Date();
   d.setDate(d.getDate() + 1);

--- a/supabase/migrations/004_add_streak_freeze.sql
+++ b/supabase/migrations/004_add_streak_freeze.sql
@@ -1,0 +1,24 @@
+-- ============================================================
+-- 004_add_streak_freeze.sql
+-- Script — Streak Freeze
+-- ============================================================
+-- Tracks streak freeze usage per user per day.
+-- Up to 3 freezes per month can be used to protect a streak.
+-- ============================================================
+
+create table streak_freezes (
+  id          uuid primary key default gen_random_uuid(),
+  user_id     uuid references auth.users not null,
+  freeze_date date not null,
+  created_at  timestamptz default now(),
+  unique (user_id, freeze_date)
+);
+
+create index idx_streak_freezes_user_date on streak_freezes(user_id, freeze_date desc);
+
+alter table streak_freezes enable row level security;
+
+create policy "users can manage own streak freezes"
+  on streak_freezes for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 概要
Streak機能のコアは実装済みだったが、3つの未実装要件「途切れそうな日の警告（At-risk状態）」「節目の祝福演出（7日・30日）」「Streak Freeze」を追加実装。

## 実装内容

### `src/lib/date.ts`
- `getYesterdayStr()` ユーティリティを追加（ローカル時間ベース）

### `supabase/migrations/004_add_streak_freeze.sql`
- `streak_freezes` テーブルを追加（月3回まで使用可能）
- RLSポリシー設定済み

### `src/hooks/useTasks.ts`
- `fetchStreak()` を `Promise<number>` を返すよう改修
- `streak_freezes` と `daily_completion_log` を `Promise.all` で並列取得
- `streakIsAtRisk`：昨日はcompletion/freeze済み、今日はまだゼロの場合に `true`
- `streakMilestone`：7日・30日到達時にセットされる state
- `availableFreezes`：当月の残りfreeze回数（3 - 使用済み）
- `applyStreakFreeze()`：今日日付で streak_freeze をupsert
- `clearStreakMilestone()`：マイルストーン表示後にリセット

### `src/components/ui/StreakMilestoneOverlay.tsx`（新規）
- 7日・30日達成時のフルスクリーンオーバーレイ
- `AnimatePresence` で滑らかなフェードイン/アウト
- 3秒後に自動でdismiss
- `font-display`（Shippori Mincho）でタイトル表示

### `src/components/ui/StreakBadge.tsx`
- `isAtRisk` / `availableFreezes` / `onFreeze` propsを追加
- at-risk時：アンバー背景、🔥のanimate-pulse、ツールチップメッセージ変更
- at-riskかつfreeze可能時：🧊 Freezeボタンを横に表示

### `src/components/features/task/TaskList.tsx`
- `streakIsAtRisk` / `availableFreezes` / `onStreakFreeze` propsを追加してStreakBadgeに渡す

### `src/app/page.tsx`
- 新stateをuseTasksから取得してTaskListに渡す
- `<StreakMilestoneOverlay>` をレンダリング

## 関連
Closes #65
実装計画: #70

🤖 Generated with Claude Code Scheduled Task