### PR TITLE
完了演出の可変報酬化：固定パーティクルをランダム演出に置き換え

### DIFF
--- a/src/components/features/task/CompletionReward.tsx
+++ b/src/components/features/task/CompletionReward.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { springTransition } from "@/lib/motion";
+import type { RewardType } from "@/lib/rewards";
+
+interface CompletionRewardProps {
+  type: RewardType;
+  linkedGoalName?: string;
+  streakDays?: number;
+  onComplete: () => void;
+}
+
+const INK_COLOR = "#2C2C28";
+
+function SubtleReward({ onComplete }: { onComplete: () => void }) {
+  const count = Math.floor(Math.random() * 3) + 3; // 3–5 dots
+  const dots = Array.from({ length: count });
+
+  return (
+    <motion.div
+      className="absolute inset-0 pointer-events-none overflow-visible"
+      initial={{ opacity: 1 }}
+      animate={{ opacity: 0 }}
+      transition={{ duration: 1.2, delay: 0.4 }}
+      onAnimationComplete={onComplete}
+    >
+      {dots.map((_, i) => {
+        const angle = (360 / count) * i;
+        const rad = (angle * Math.PI) / 180;
+        const x = Math.cos(rad) * 18;
+        const y = Math.sin(rad) * 18;
+        return (
+          <motion.div
+            key={i}
+            className="absolute top-1/2 left-1/2 w-1.5 h-1.5 rounded-full"
+            style={{ backgroundColor: INK_COLOR, opacity: 0.5 }}
+            initial={{ x: 0, y: 0, scale: 1 }}
+            animate={{ x, y, scale: 0 }}
+            transition={{ ...springTransition, duration: 0.6, delay: i * 0.04 }}
+          />
+        );
+      })}
+    </motion.div>
+  );
+}
+
+function BurstReward({ onComplete }: { onComplete: () => void }) {
+  const count = 8;
+  const dots = Array.from({ length: count });
+
+  return (
+    <motion.div
+      className="absolute inset-0 pointer-events-none overflow-visible"
+      initial={{ opacity: 1 }}
+      animate={{ opacity: 0 }}
+      transition={{ duration: 1.4, delay: 0.5 }}
+      onAnimationComplete={onComplete}
+    >
+      {dots.map((_, i) => {
+        const angle = (360 / count) * i;
+        const rad = (angle * Math.PI) / 180;
+        const dist = 24 + Math.random() * 8;
+        const x = Math.cos(rad) * dist;
+        const y = Math.sin(rad) * dist;
+        const size = 6 + Math.floor(Math.random() * 4);
+        return (
+          <motion.div
+            key={i}
+            className="absolute top-1/2 left-1/2 rounded-full"
+            style={{ backgroundColor: INK_COLOR, opacity: 0.7, width: size, height: size }}
+            initial={{ x: 0, y: 0, scale: 1 }}
+            animate={{ x, y, scale: 0 }}
+            transition={{ type: "spring", stiffness: 200, damping: 14, delay: i * 0.03 }}
+          />
+        );
+      })}
+    </motion.div>
+  );
+}
+
+function StreakBoostReward({ streakDays, onComplete }: { streakDays: number; onComplete: () => void }) {
+  return (
+    <motion.div
+      className="absolute inset-0 flex items-center justify-center pointer-events-none overflow-visible"
+      onAnimationComplete={onComplete}
+    >
+      <motion.div
+        className="flex flex-col items-center gap-0.5"
+        initial={{ scale: 0.5, opacity: 0, y: 4 }}
+        animate={{ scale: [0.5, 1.8, 1.4, 1], opacity: [0, 1, 1, 0], y: [4, -8, -12, -20] }}
+        transition={{ duration: 1.6, times: [0, 0.3, 0.6, 1] }}
+      >
+        <span className="text-2xl leading-none select-none">🔥</span>
+        <span className="text-xs font-bold text-foreground/80 tabular-nums">{streakDays}日</span>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+function QuoteReward({ linkedGoalName, onComplete }: { linkedGoalName: string; onComplete: () => void }) {
+  return (
+    <motion.div
+      className="absolute left-0 right-0 pointer-events-none z-10"
+      style={{ bottom: "calc(100% + 4px)" }}
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -4 }}
+      transition={springTransition}
+      onAnimationComplete={onComplete}
+    >
+      <motion.div
+        className="glass px-3 py-2 rounded-xl border border-compass-border text-xs text-compass flex items-center gap-2 shadow-sm"
+        initial={{ opacity: 1 }}
+        animate={{ opacity: 0 }}
+        transition={{ duration: 0.6, delay: 2 }}
+      >
+        <span className="text-compass/80 flex-shrink-0">🧭</span>
+        <span className="truncate">{linkedGoalName}</span>
+      </motion.div>
+    </motion.div>
+  );
+}
+
+export function CompletionReward({ type, linkedGoalName = "", streakDays = 0, onComplete }: CompletionRewardProps) {
+  if (type === 'streak_boost') {
+    return <StreakBoostReward streakDays={streakDays} onComplete={onComplete} />;
+  }
+  if (type === 'burst') {
+    return <BurstReward onComplete={onComplete} />;
+  }
+  if (type === 'quote' && linkedGoalName) {
+    return <QuoteReward linkedGoalName={linkedGoalName} onComplete={onComplete} />;
+  }
+  return <SubtleReward onComplete={onComplete} />;
+}

--- a/src/components/features/task/TaskItem.tsx
+++ b/src/components/features/task/TaskItem.tsx
@@ -4,11 +4,13 @@ import { useState, useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { CheckCircle2, Circle, Compass, X, GripVertical, Pencil, Play, Undo2, Wand2, Send, Loader2, CalendarDays } from "lucide-react";
 import { SchedulingPicker } from "./SchedulingPicker";
+import { CompletionReward } from "./CompletionReward";
 import { cn } from "@/lib/utils";
 import { springTransition } from "@/lib/motion";
 import { formatScheduleBadge } from "@/lib/date";
 import { toast } from "sonner";
 import { ApiError, getUserFriendlyErrorMessage, NETWORK_ERROR_MESSAGE } from "@/lib/errors";
+import { pickReward, type RewardType } from "@/lib/rewards";
 
 export type TaskStatus = 'todo' | 'in_progress' | 'done' | 'canceled';
 
@@ -44,6 +46,7 @@ interface TaskItemProps {
   onDragOver?: (index: number) => void;
   onDragEnd?: () => void;
   isSubTask?: boolean;
+  streakDays?: number;
 }
 
 const itemVariants = {
@@ -66,8 +69,10 @@ export function TaskItem({
   onDragOver,
   onDragEnd,
   isSubTask = false,
+  streakDays = 0,
 }: TaskItemProps) {
   const [isEditing, setIsEditing] = useState(false);
+  const [activeReward, setActiveReward] = useState<RewardType | null>(null);
   const [editValue, setEditValue] = useState(task.title);
   const [isExpanded, setIsExpanded] = useState(false);
   const [showAllSubtasks, setShowAllSubtasks] = useState(false);
@@ -86,6 +91,20 @@ export function TaskItem({
   ).length;
   const progressPercentage = hasSubtasks ? (completedSubtasks / totalSubtasks) * 100 : 0;
   const isAllSubtasksCompleted = hasSubtasks && completedSubtasks === totalSubtasks;
+
+  const handleToggle = () => {
+    const willComplete = task.status !== 'done';
+    if (willComplete) {
+      const rewardType = pickReward({
+        hasLinkedGoal: !!task.linkedGoal,
+        linkedGoalName: task.linkedGoal ?? '',
+        isAllSubtasksCompleted,
+        streakDaysAfter: streakDays + 1,
+      });
+      setActiveReward(rewardType);
+    }
+    onToggle(task.id);
+  };
 
   useEffect(() => {
     if (isEditing && inputRef.current) {
@@ -184,10 +203,10 @@ export function TaskItem({
 
         {/* Toggle button */}
         <motion.button
-          onClick={() => onToggle(task.id)}
+          onClick={handleToggle}
           aria-label={task.status === "done" ? "タスクを未完了に戻す" : "タスクを完了する"}
           className={cn(
-            "group/toggle mt-1 relative flex items-center justify-center flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors",
+            "group/toggle mt-1 relative flex items-center justify-center flex-shrink-0 text-muted-foreground hover:text-foreground transition-colors overflow-visible",
             isSubTask ? "w-4 h-4" : "w-6 h-6"
           )}
           whileTap={{ scale: 0.8 }}
@@ -260,6 +279,17 @@ export function TaskItem({
               )}
             />
           )}
+          <AnimatePresence>
+            {activeReward !== null && (
+              <CompletionReward
+                key={activeReward}
+                type={activeReward}
+                linkedGoalName={task.linkedGoal}
+                streakDays={streakDays + 1}
+                onComplete={() => setActiveReward(null)}
+              />
+            )}
+          </AnimatePresence>
         </motion.button>
 
         {/* Content */}

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -176,6 +176,7 @@ export function TaskList({
               onDragOver={handleDragOver}
               onDragEnd={handleDragEnd}
               isSubTask={compact}
+              streakDays={streakDays}
             />
           ))}
           {groupTasks.length === 0 && showEmptyIfZero && (

--- a/src/lib/rewards.ts
+++ b/src/lib/rewards.ts
@@ -1,0 +1,26 @@
+export type RewardType = 'subtle' | 'burst' | 'streak_boost' | 'quote';
+
+export interface RewardContext {
+  hasLinkedGoal: boolean;
+  linkedGoalName: string;
+  isAllSubtasksCompleted: boolean;
+  streakDaysAfter: number;
+}
+
+const STREAK_MILESTONES = [3, 7, 14, 30] as const;
+
+export function pickReward(ctx: RewardContext): RewardType {
+  if (STREAK_MILESTONES.includes(ctx.streakDaysAfter as (typeof STREAK_MILESTONES)[number])) {
+    return 'streak_boost';
+  }
+  if (ctx.isAllSubtasksCompleted) {
+    return 'burst';
+  }
+  if (ctx.hasLinkedGoal && Math.random() < 0.3) {
+    return 'quote';
+  }
+  if (Math.random() < 0.2) {
+    return 'burst';
+  }
+  return 'subtle';
+}


### PR DESCRIPTION
## 概要

タスク完了時の演出を固定パターンから文脈依存のランダム演出（Variable Reward）に変更する。Hooked モデルの可変報酬原則と Peak-End Rule に基づき、通常は控えめ、節目には大きな演出を集中投下する。

## 実装内容

### 新規ファイル
- **`src/lib/rewards.ts`**: `RewardType` / `RewardContext` 型と `pickReward()` 関数
  - 優先度: `streak_boost`（3/7/14/30日節目）> `burst`（全サブタスク完了）> `quote`（linkedGoal有り+30%乱数）> `burst`（20%乱数）> `subtle`
- **`src/components/features/task/CompletionReward.tsx`**: 4種の演出コンポーネント
  - `SubtleReward`: インクドロップ風の3〜5ドット放射（通常完了）
  - `BurstReward`: 8ドットのSpring弾性放射（節目・親タスク完了）
  - `StreakBoostReward`: 🔥エモジのバウンス + Streak日数カウント表示
  - `QuoteReward`: linkedGoal名を含むglassカードが下から浮上し2秒後フェード

### 変更ファイル
- **`src/components/features/task/TaskItem.tsx`**: `streakDays` prop追加、`handleToggle`内で`pickReward`呼び出し、`AnimatePresence`で`CompletionReward`をレンダリング
- **`src/components/features/task/TaskList.tsx`**: `streakDays`を`TaskItem`に受け渡し

### デザイン準拠
- 演出カラー: `#2C2C28`（インクブラック）/ `glass` ユーティリティ
- アニメーション: Framer Motion の `springTransition` ベース
- すべて `pointer-events-none` で UI 操作を妨げない
- 1〜2秒以内に自動消去

## 関連

Closes #66
実装計画: #71

🤖 Generated with Claude Code Scheduled Task