### PR TITLE
Streak機能強化：at-risk警告・マイルストーン祝福・Streak Freeze

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -35,6 +35,11 @@
   --color-compass-muted: #235454;
   --color-compass-subtle: rgba(45, 106, 106, 0.08);
   --color-compass-border: rgba(45, 106, 106, 0.18);
+
+  /* Warning: at-risk 状態 — 古びた赤インク。危機感を伝えるが威圧しない */
+  --color-warning: #8B4513;
+  --color-warning-subtle: rgba(139, 69, 19, 0.1);
+  --color-warning-border: rgba(139, 69, 19, 0.25);
 }
 
 /*

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,6 +9,7 @@ import { useLists } from "@/hooks/useLists";
 import { motion, AnimatePresence } from "framer-motion";
 import { Trash2, Sparkles } from "lucide-react";
 import { toast } from "sonner";
+import { StreakMilestoneOverlay } from "@/components/ui/StreakMilestoneOverlay";
 
 const springTransition = { type: "spring" as const, stiffness: 260, damping: 20 };
 
@@ -36,8 +37,13 @@ export default function Home() {
     isBreakingDown,
     completedCount,
     streakDays,
+    streakIsAtRisk,
+    streakMilestone,
+    availableFreezes,
     scheduleTask,
     unscheduleTask,
+    applyStreakFreeze,
+    clearStreakMilestone,
   } = useTasks();
 
   const handleBreakdown = async (prompt: string) => {
@@ -56,6 +62,8 @@ export default function Home() {
   }, [deleteTask, undoDelete]);
 
   return (
+    <>
+    <StreakMilestoneOverlay milestone={streakMilestone} onDismiss={clearStreakMilestone} />
     <div className="flex flex-col items-center w-full max-w-3xl mx-auto space-y-4 pt-2 sm:pt-4">
       <div className="text-center space-y-1">
         <h1 className="font-display text-xl sm:text-2xl font-bold tracking-tighter bg-clip-text text-transparent bg-gradient-to-br from-foreground to-foreground/50">
@@ -113,6 +121,9 @@ export default function Home() {
               newlyBreakdownTaskId={lastBreakdownTaskId}
               onDismissSchedulingPrompt={() => setLastBreakdownTaskId(null)}
               streakDays={streakDays}
+              streakIsAtRisk={streakIsAtRisk}
+              availableFreezes={availableFreezes}
+              onStreakFreeze={applyStreakFreeze}
             />
 
             {/* Bulk action bar */}
@@ -142,5 +153,6 @@ export default function Home() {
         )}
       </div>
     </div>
+    </>
   );
 }

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -34,6 +34,9 @@ interface TaskListProps {
   newlyBreakdownTaskId?: string | null;
   onDismissSchedulingPrompt?: () => void;
   streakDays?: number;
+  streakIsAtRisk?: boolean;
+  availableFreezes?: number;
+  onStreakFreeze?: () => void;
 }
 
 interface TaskWithIndex extends Task {
@@ -70,6 +73,9 @@ export function TaskList({
   newlyBreakdownTaskId,
   onDismissSchedulingPrompt,
   streakDays = 0,
+  streakIsAtRisk = false,
+  availableFreezes = 0,
+  onStreakFreeze,
 }: TaskListProps) {
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
@@ -272,7 +278,12 @@ export function TaskList({
             Today
           </button>
         </div>
-        <StreakBadge days={streakDays} />
+        <StreakBadge
+          days={streakDays}
+          isAtRisk={streakIsAtRisk}
+          availableFreezes={availableFreezes}
+          onFreeze={onStreakFreeze}
+        />
       </div>
 
       {/* Breakdown直後のインラインスケジューリングプロンプト */}

--- a/src/components/features/task/TaskList.tsx
+++ b/src/components/features/task/TaskList.tsx
@@ -35,7 +35,7 @@ interface TaskListProps {
   onDismissSchedulingPrompt?: () => void;
   streakDays?: number;
   streakIsAtRisk?: boolean;
-  availableFreezes?: number;
+  availableFreezes?: number | null;
   onStreakFreeze?: () => void;
 }
 
@@ -281,8 +281,8 @@ export function TaskList({
         <StreakBadge
           days={streakDays}
           isAtRisk={streakIsAtRisk}
-          availableFreezes={availableFreezes}
-          onFreeze={onStreakFreeze}
+          availableFreezes={availableFreezes ?? 0}
+          onFreeze={availableFreezes !== null ? onStreakFreeze : undefined}
         />
       </div>
 

--- a/src/components/ui/StreakBadge.tsx
+++ b/src/components/ui/StreakBadge.tsx
@@ -6,34 +6,71 @@ import { cn } from "@/lib/utils";
 
 interface StreakBadgeProps {
   days: number;
+  isAtRisk?: boolean;
+  availableFreezes?: number;
+  onFreeze?: () => void;
   className?: string;
 }
 
-export function StreakBadge({ days, className }: StreakBadgeProps) {
+export function StreakBadge({
+  days,
+  isAtRisk = false,
+  availableFreezes = 0,
+  onFreeze,
+  className,
+}: StreakBadgeProps) {
   const isActive = days > 0;
+  const canFreeze = isAtRisk && availableFreezes > 0 && onFreeze;
 
   return (
-    <motion.div
-      className={cn(
-        "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium transition-colors",
-        isActive
-          ? "bg-primary/10 border border-primary/20 text-foreground"
-          : "bg-secondary/30 border border-foreground/10 text-muted-foreground",
-        className
-      )}
-      whileHover={{ y: -1 }}
-      transition={springTransition}
-      title={isActive ? `${days}日連続でタスクを完了しています` : "今日タスクを完了して連続記録を始めよう"}
-    >
-      <span className={cn("text-sm", isActive ? "opacity-100" : "opacity-40")}>🔥</span>
-      {isActive ? (
-        <span>
-          <span className="font-bold text-sm">{days}</span>
-          <span className="text-muted-foreground ml-0.5">日連続</span>
+    <div className={cn("flex items-center gap-2", className)}>
+      <motion.div
+        className={cn(
+          "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium transition-colors",
+          isAtRisk
+            ? "bg-amber-500/15 border border-amber-500/30 text-amber-700 animate-pulse"
+            : isActive
+            ? "bg-primary/10 border border-primary/20 text-foreground"
+            : "bg-secondary/30 border border-foreground/10 text-muted-foreground"
+        )}
+        whileHover={{ y: -1 }}
+        transition={springTransition}
+        title={
+          isAtRisk
+            ? "今日タスクを完了しないとStreakが途切れます！"
+            : isActive
+            ? `${days}日連続でタスクを完了しています`
+            : "今日タスクを完了して連続記録を始めよう"
+        }
+      >
+        <span className={cn("text-sm", isActive ? "opacity-100" : "opacity-40")}>
+          {isAtRisk ? "⚠️" : "🔥"}
         </span>
-      ) : (
-        <span>連続記録を始めよう</span>
+        {isActive ? (
+          <span>
+            <span className="font-bold text-sm">{days}</span>
+            <span className={cn("ml-0.5", isAtRisk ? "text-amber-700/70" : "text-muted-foreground")}>
+              日連続
+            </span>
+          </span>
+        ) : (
+          <span>連続記録を始めよう</span>
+        )}
+      </motion.div>
+
+      {canFreeze && (
+        <motion.button
+          onClick={onFreeze}
+          className="flex items-center gap-1 px-2.5 py-1.5 rounded-xl text-xs font-medium bg-sky-500/15 border border-sky-500/30 text-sky-700 hover:bg-sky-500/25 transition-colors"
+          whileHover={{ y: -1 }}
+          whileTap={{ scale: 0.95 }}
+          transition={springTransition}
+          title={`Streak Freeze を使う（残り${availableFreezes}回）`}
+        >
+          🧊 <span className="hidden sm:inline">Freeze</span>
+          <span className="text-sky-700/60 text-xs">×{availableFreezes}</span>
+        </motion.button>
       )}
-    </motion.div>
+    </div>
   );
 }

--- a/src/components/ui/StreakBadge.tsx
+++ b/src/components/ui/StreakBadge.tsx
@@ -28,7 +28,7 @@ export function StreakBadge({
         className={cn(
           "flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-xs font-medium transition-colors",
           isAtRisk
-            ? "bg-amber-500/15 border border-amber-500/30 text-amber-700 animate-pulse"
+            ? "bg-warning-subtle border border-warning-border text-warning animate-pulse"
             : isActive
             ? "bg-primary/10 border border-primary/20 text-foreground"
             : "bg-secondary/30 border border-foreground/10 text-muted-foreground"
@@ -49,7 +49,7 @@ export function StreakBadge({
         {isActive ? (
           <span>
             <span className="font-bold text-sm">{days}</span>
-            <span className={cn("ml-0.5", isAtRisk ? "text-amber-700/70" : "text-muted-foreground")}>
+            <span className={cn("ml-0.5", isAtRisk ? "text-warning/70" : "text-muted-foreground")}>
               日連続
             </span>
           </span>
@@ -61,14 +61,14 @@ export function StreakBadge({
       {canFreeze && (
         <motion.button
           onClick={onFreeze}
-          className="flex items-center gap-1 px-2.5 py-1.5 rounded-xl text-xs font-medium bg-sky-500/15 border border-sky-500/30 text-sky-700 hover:bg-sky-500/25 transition-colors"
+          className="flex items-center gap-1 px-2.5 py-1.5 rounded-xl text-xs font-medium bg-compass-subtle border border-compass-border text-compass hover:bg-compass-subtle/60 transition-colors"
           whileHover={{ y: -1 }}
           whileTap={{ scale: 0.95 }}
           transition={springTransition}
           title={`Streak Freeze を使う（残り${availableFreezes}回）`}
         >
           🧊 <span className="hidden sm:inline">Freeze</span>
-          <span className="text-sky-700/60 text-xs">×{availableFreezes}</span>
+          <span className="text-compass/60 text-xs">×{availableFreezes}</span>
         </motion.button>
       )}
     </div>

--- a/src/components/ui/StreakMilestoneOverlay.tsx
+++ b/src/components/ui/StreakMilestoneOverlay.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useEffect } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { springTransition } from "@/lib/motion";
+
+interface StreakMilestoneOverlayProps {
+  milestone: 7 | 30 | null;
+  onDismiss: () => void;
+}
+
+const MILESTONE_MESSAGES: Record<7 | 30, { emoji: string; title: string; subtitle: string }> = {
+  7: {
+    emoji: "🔥",
+    title: "7日連続達成！",
+    subtitle: "一週間、毎日積み上げました。この調子で続けよう。",
+  },
+  30: {
+    emoji: "🏆",
+    title: "30日連続達成！",
+    subtitle: "一ヶ月間、毎日前進し続けました。あなたは本物です。",
+  },
+};
+
+export function StreakMilestoneOverlay({ milestone, onDismiss }: StreakMilestoneOverlayProps) {
+  useEffect(() => {
+    if (!milestone) return;
+    const timer = setTimeout(onDismiss, 3000);
+    return () => clearTimeout(timer);
+  }, [milestone, onDismiss]);
+
+  const message = milestone ? MILESTONE_MESSAGES[milestone] : null;
+
+  return (
+    <AnimatePresence>
+      {milestone && message && (
+        <motion.div
+          key={`milestone-${milestone}`}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.3 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/40 backdrop-blur-sm"
+          onClick={onDismiss}
+        >
+          <motion.div
+            initial={{ scale: 0.8, y: 20, opacity: 0 }}
+            animate={{ scale: 1, y: 0, opacity: 1 }}
+            exit={{ scale: 0.8, y: 20, opacity: 0 }}
+            transition={springTransition}
+            className="flex flex-col items-center gap-4 px-10 py-10 rounded-3xl glass shadow-2xl text-center max-w-sm mx-4"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <motion.span
+              className="text-6xl"
+              animate={{ scale: [1, 1.2, 1] }}
+              transition={{ delay: 0.2, duration: 0.5, ease: "easeOut" }}
+            >
+              {message.emoji}
+            </motion.span>
+            <h2 className="font-display text-3xl font-bold text-foreground tracking-tight">
+              {message.title}
+            </h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {message.subtitle}
+            </p>
+            <p className="text-xs text-muted-foreground/60 mt-2">タップで閉じる</p>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
-import { getTodayStr, getYesterdayStr } from "@/lib/date";
+import { getTodayStr, getYesterdayStr, toDateStr } from "@/lib/date";
 import { createClient } from "@/lib/supabase/client";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -21,7 +21,7 @@ export function useTasks() {
   const [streakDays, setStreakDays] = useState(0);
   const [streakIsAtRisk, setStreakIsAtRisk] = useState(false);
   const [streakMilestone, setStreakMilestone] = useState<7 | 30 | null>(null);
-  const [availableFreezes, setAvailableFreezes] = useState(3);
+  const [availableFreezes, setAvailableFreezes] = useState<number | null>(null);
 
   const supabase = useMemo(() => createClient(), []);
 
@@ -110,7 +110,8 @@ export function useTasks() {
         .from("streak_freezes")
         .select("freeze_date")
         .eq("user_id", user.id)
-        .order("freeze_date", { ascending: false }),
+        .order("freeze_date", { ascending: false })
+        .limit(365),
     ]);
 
     const logData = logResult.data ?? [];
@@ -149,9 +150,11 @@ export function useTasks() {
 
     while (isCredited(cursor)) {
       streak++;
-      const [y, m, d] = cursor.split("-").map(Number);
-      const prev = new Date(Date.UTC(y!, m! - 1, d! - 1));
-      cursor = prev.toISOString().split("T")[0] ?? cursor;
+      const parts = cursor.split("-").map(Number);
+      if (parts.length < 3 || parts.some(isNaN)) break;
+      const [y, m, d] = parts as [number, number, number];
+      const prevDate = new Date(y, m - 1, d - 1);
+      cursor = toDateStr(prevDate);
     }
 
     setStreakDays(streak);
@@ -200,6 +203,20 @@ export function useTasks() {
     if (!user) return;
 
     const today = getTodayStr();
+    const currentMonth = today.slice(0, 7);
+
+    // サーバーサイドで当月の使用数を再確認してから挿入
+    const { count } = await supabase
+      .from("streak_freezes")
+      .select("*", { count: "exact", head: true })
+      .eq("user_id", user.id)
+      .gte("freeze_date", `${currentMonth}-01`);
+
+    if ((count ?? 0) >= 3) {
+      toast.error("今月のStreak Freezeは使い切りました（月3回まで）");
+      return;
+    }
+
     await supabase
       .from("streak_freezes")
       .upsert({ user_id: user.id, freeze_date: today }, { onConflict: "user_id,freeze_date" });

--- a/src/hooks/useTasks.ts
+++ b/src/hooks/useTasks.ts
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { Task, TaskStatus } from "@/components/features/task/TaskItem";
 import { v4 as uuidv4 } from "uuid";
 import { BreakdownResponseSchema, BreakdownTaskSchema } from "@/lib/schemas";
-import { getTodayStr } from "@/lib/date";
+import { getTodayStr, getYesterdayStr } from "@/lib/date";
 import { createClient } from "@/lib/supabase/client";
 import { z } from "zod";
 import { toast } from "sonner";
@@ -19,6 +19,9 @@ export function useTasks() {
   const [isLoading, setIsLoading] = useState(false);
   const [isFetching, setIsFetching] = useState(true);
   const [streakDays, setStreakDays] = useState(0);
+  const [streakIsAtRisk, setStreakIsAtRisk] = useState(false);
+  const [streakMilestone, setStreakMilestone] = useState<7 | 30 | null>(null);
+  const [availableFreezes, setAvailableFreezes] = useState(3);
 
   const supabase = useMemo(() => createClient(), []);
 
@@ -93,38 +96,80 @@ export function useTasks() {
     const { data: { user } } = await supabase.auth.getUser();
     if (!user) return;
 
-    const { data } = await supabase
-      .from("daily_completion_log")
-      .select("log_date")
-      .eq("user_id", user.id)
-      .order("log_date", { ascending: false })
-      .limit(365);
-
-    if (!data || data.length === 0) {
-      setStreakDays(0);
-      return;
-    }
-
     const LogRowSchema = z.object({ log_date: z.string() });
+    const FreezeRowSchema = z.object({ freeze_date: z.string() });
+
+    const [logResult, freezeResult] = await Promise.all([
+      supabase
+        .from("daily_completion_log")
+        .select("log_date")
+        .eq("user_id", user.id)
+        .order("log_date", { ascending: false })
+        .limit(365),
+      supabase
+        .from("streak_freezes")
+        .select("freeze_date")
+        .eq("user_id", user.id)
+        .order("freeze_date", { ascending: false }),
+    ]);
+
+    const logData = logResult.data ?? [];
+    const freezeData = freezeResult.data ?? [];
+
+    const completedDates = new Set(
+      logData
+        .map((r) => LogRowSchema.safeParse(r))
+        .filter((p) => p.success)
+        .map((p) => p.data.log_date)
+    );
+    const freezeDates = new Set(
+      freezeData
+        .map((r) => FreezeRowSchema.safeParse(r))
+        .filter((p) => p.success)
+        .map((p) => p.data.freeze_date)
+    );
+
+    // 当月の使用済みFreeze数 → 残り回数を計算
+    const currentMonth = getTodayStr().slice(0, 7);
+    const usedFreezesThisMonth = [...freezeDates].filter((d) =>
+      d.startsWith(currentMonth)
+    ).length;
+    setAvailableFreezes(Math.max(0, 3 - usedFreezesThisMonth));
 
     const today = getTodayStr();
-    let streak = 0;
-    let cursor = today;
+    const yesterday = getYesterdayStr();
 
-    for (const row of data) {
-      const parsed = LogRowSchema.safeParse(row);
-      if (!parsed.success) break;
-      if (parsed.data.log_date === cursor) {
-        streak++;
-        const [y, m, d] = cursor.split("-").map(Number);
-        const prev = new Date(Date.UTC(y!, m! - 1, d! - 1));
-        cursor = prev.toISOString().split("T")[0] ?? cursor;
-      } else {
-        break;
-      }
+    const isCredited = (date: string) =>
+      completedDates.has(date) || freezeDates.has(date);
+
+    // 今日が未クレジットなら昨日からカウント開始（at-risk状態）
+    const startFromYesterday = !isCredited(today);
+    let cursor = startFromYesterday ? yesterday : today;
+    let streak = 0;
+
+    while (isCredited(cursor)) {
+      streak++;
+      const [y, m, d] = cursor.split("-").map(Number);
+      const prev = new Date(Date.UTC(y!, m! - 1, d! - 1));
+      cursor = prev.toISOString().split("T")[0] ?? cursor;
     }
 
     setStreakDays(streak);
+
+    // at-risk: streakが1以上かつ今日未クレジット
+    const isAtRisk = streak > 0 && startFromYesterday && isCredited(yesterday);
+    setStreakIsAtRisk(isAtRisk);
+
+    // マイルストーン判定（既読フラグはlocalStorageで管理）
+    if (streak === 7 || streak === 30) {
+      const milestoneKey = `streak_milestone_seen_${streak}`;
+      const alreadySeen =
+        typeof window !== "undefined" &&
+        localStorage.getItem(milestoneKey) === "true";
+      if (!alreadySeen) {
+        setStreakMilestone(streak);
+      }
+    }
   }, [supabase]);
 
   useEffect(() => {
@@ -149,6 +194,25 @@ export function useTasks() {
 
     void fetchStreak();
   }, [supabase, fetchStreak]);
+
+  const applyStreakFreeze = useCallback(async () => {
+    const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
+
+    const today = getTodayStr();
+    await supabase
+      .from("streak_freezes")
+      .upsert({ user_id: user.id, freeze_date: today }, { onConflict: "user_id,freeze_date" });
+
+    void fetchStreak();
+  }, [supabase, fetchStreak]);
+
+  const clearStreakMilestone = useCallback(() => {
+    if (streakMilestone !== null && typeof window !== "undefined") {
+      localStorage.setItem(`streak_milestone_seen_${streakMilestone}`, "true");
+    }
+    setStreakMilestone(null);
+  }, [streakMilestone]);
 
   // ─── CRUD ───────────────────────────────────────────────────────────────────
 
@@ -797,6 +861,9 @@ export function useTasks() {
     isBreakingDown: isLoading,
     completedCount,
     streakDays,
+    streakIsAtRisk,
+    streakMilestone,
+    availableFreezes,
     todayTasks,
     scheduledTasks,
     somedayTasks,
@@ -815,5 +882,7 @@ export function useTasks() {
     importFromRoadmap,
     scheduleTask,
     unscheduleTask,
+    applyStreakFreeze,
+    clearStreakMilestone,
   };
 }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -6,6 +6,12 @@ export function getTodayStr(): string {
   return toDateStr(new Date());
 }
 
+export function getYesterdayStr(): string {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  return toDateStr(d);
+}
+
 export function getTomorrowStr(): string {
   const d = new Date();
   d.setDate(d.getDate() + 1);

--- a/supabase/migrations/005_add_streak_freeze.sql
+++ b/supabase/migrations/005_add_streak_freeze.sql
@@ -1,0 +1,21 @@
+-- ============================================================
+-- 005_add_streak_freeze.sql
+-- Streak Freeze: 月3回まで利用可能なStreakの保護機能
+-- ============================================================
+
+create table streak_freezes (
+  id         uuid primary key default gen_random_uuid(),
+  user_id    uuid references auth.users not null,
+  freeze_date date not null,
+  created_at  timestamptz default now(),
+  unique (user_id, freeze_date)
+);
+
+create index idx_streak_freezes_user_date on streak_freezes(user_id, freeze_date desc);
+
+alter table streak_freezes enable row level security;
+
+create policy "users can manage own streak freezes"
+  on streak_freezes for all
+  using (auth.uid() = user_id)
+  with check (auth.uid() = user_id);


### PR DESCRIPTION
## 概要
Streak機能のコア（連続日数の記録・表示）に、行動設計上の3要素を追加実装した。

## 実装内容

### 1. `streak_freezes` テーブル（マイグレーション）
- `supabase/migrations/005_add_streak_freeze.sql` を追加
- ユーザーごとに日付をキーとして保存、RLSポリシーを設定

### 2. `useTasks.ts` — fetchStreak() の拡張
- `daily_completion_log` と `streak_freezes` を `Promise.all` で並列取得
- `isCredited(date)` で completion / freeze を統一判定してstreakを計算
- 新state: `streakIsAtRisk`（今日未クレジットかつ昨日はクレジット済み）
- 新state: `streakMilestone`（7日/30日到達時、localStorageで既読管理）
- 新state: `availableFreezes`（当月3回 - 使用済み数）
- 新メソッド: `applyStreakFreeze()` / `clearStreakMilestone()`

### 3. `StreakBadge.tsx` — at-risk演出とFreezeボタン
- `isAtRisk` 時はアンバー背景 + `animate-pulse` + `⚠️`アイコン
- `canFreeze` 時は🧊Freezeボタンを隣に表示（残り回数付き）

### 4. `StreakMilestoneOverlay.tsx`（新規）
- 7日・30日到達時にフルスクリーンオーバーレイを3秒表示
- `AnimatePresence` でフェードイン/アウト、spring遷移でスケールアップ
- タップでも即時dismissでき、既読フラグをlocalStorageに保存

### 5. 配線
- `TaskList.tsx`: `streakIsAtRisk` / `availableFreezes` / `onStreakFreeze` propsを追加して `StreakBadge` に渡す
- `page.tsx`: 新stateをuseTasksから取得して `TaskList` に渡し、`StreakMilestoneOverlay` をレンダリング

## 関連
Closes #75
実装計画: #81

🤖 Generated with Claude Code Scheduled Task
